### PR TITLE
지난 섭취 기록 - 지난 기록 추가 기능 구현

### DIFF
--- a/app/(tabs)/components/AddNewRecord.styles.ts
+++ b/app/(tabs)/components/AddNewRecord.styles.ts
@@ -1,24 +1,10 @@
 import { StyleSheet } from "react-native";
-import { horizontalScale, marginScale, verticalScale } from "@/libs/utils/scaling";
-import { commonStyles } from "@/components/common.styles";
+import { verticalScale } from "@/libs/utils/scaling";
 
 const addNewRecordStyles = StyleSheet.create({
   bottomSheetContainer: {
     flex: 1,
     gap: verticalScale(24),
-  },
-  header: {
-    ...commonStyles.flexRow,
-    justifyContent: "space-between",
-  },
-  inputMeasurement: {
-    ...commonStyles.flexRow,
-    gap: horizontalScale(12),
-    alignItems: "center",
-  },
-  sliderWrapper: {
-    flex: 1,
-    ...marginScale(20, 0),
   },
 });
 

--- a/app/(tabs)/components/AddNewRecord.tsx
+++ b/app/(tabs)/components/AddNewRecord.tsx
@@ -16,7 +16,7 @@ interface addNewRecordProps {
 
 const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
   const [currentTab, setCurrentTab] = useState<TabType>("물");
-  const [currentVal, setCurrentVal] = useState(500);
+  const [currentVal, setCurrentVal] = useState(50);
   const { currentIndex } = useBeverageStore();
 
   const addAmount = () => {

--- a/app/(tabs)/components/AddNewRecord.tsx
+++ b/app/(tabs)/components/AddNewRecord.tsx
@@ -4,12 +4,10 @@ import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet"
 import { CustomTab, TabType } from "@/components/CustomTab";
 import React, { useState } from "react";
 import { View } from "react-native";
-import CustomSlider from "@/components/CustomSlider/CustomSlider";
-import { BN1, LN1 } from "@/components/ThemedText";
-import { Colors } from "@/constants/Colors";
 import CustomButton from "@/components/CustomButton/CustomButton";
 import { useBeverageStore } from "@/stores/beverageStore";
 import { dummyBeverages } from "@/app/(tabs)/constants/beverageDataSet";
+import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
 
 interface addNewRecordProps {
   isOpen: boolean;
@@ -38,27 +36,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
           />
         </View>
 
-        <View style={addNewRecordStyles.header}>
-          <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
-            마신 양을 얼마나 추가할까요?
-          </BN1>
-
-          <View style={addNewRecordStyles.inputMeasurement}>
-            <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
-              {currentVal}
-            </BN1>
-            <LN1 lightColor={Colors.neutral_400}>ml</LN1>
-          </View>
-        </View>
-
-        <CustomSlider
-          sliderVal={currentVal}
-          onValueChange={(val) => setCurrentVal(val[0])}
-          step={50}
-          animationType={"spring"}
-          maximumValue={1000}
-          minimumValue={0}
-        />
+        <RecordAmountSection currentVal={currentVal} setCurrentVal={setCurrentVal} />
 
         <CustomButton title={"확인"} textStyle={{ fontWeight: "bold" }} onPress={addAmount} />
       </View>

--- a/app/(tabs)/index.styles.ts
+++ b/app/(tabs)/index.styles.ts
@@ -4,7 +4,6 @@ import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
 
 export const tabsStyles = StyleSheet.create({
   mainContainer: {
-    flex: 1,
     ...commonStyles.pageContainer,
     ...commonStyles.transparentView,
   },

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,6 +8,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import renderItem from "@/app/(tabs)/utils/renderItem";
 import beverageDataSet from "@/app/(tabs)/constants/beverageDataSet";
 import AddNewRecord from "@/app/(tabs)/components/AddNewRecord";
+import CustomButton from "@/components/CustomButton/CustomButton";
+import { useRouter } from "expo-router";
 
 const { width: screenWidth } = Dimensions.get("window");
 const DESIGN_WIDTH = 375;
@@ -16,6 +18,7 @@ const bgHeight = (screenWidth / DESIGN_WIDTH) * DESIGN_HEIGHT;
 
 export default function HomeScreen() {
   const [isAddNewRecordOpen, setIsAddNewRecordOpen] = useState(false);
+  const router = useRouter();
 
   const handleBottomSheetOpen = () => {
     setIsAddNewRecordOpen(!isAddNewRecordOpen);
@@ -45,6 +48,12 @@ export default function HomeScreen() {
               })}
             />
           </View>
+
+          <CustomButton
+            title={"섭취 기록으로(임시)"}
+            variant={"secondary"}
+            onPress={() => router.push("/record-history")}
+          />
         </ScrollView>
       </SafeAreaView>
       <AddNewRecord isOpen={isAddNewRecordOpen} onClose={() => setIsAddNewRecordOpen(false)} />

--- a/app/onboard-survey/_layout.tsx
+++ b/app/onboard-survey/_layout.tsx
@@ -1,10 +1,7 @@
-import { ThemedView } from "@/components/ThemedView";
-import { Colors } from "@/constants/Colors";
 import { useOnboardStepStore } from "@/stores/onboardStepStore";
-import { MaterialIcons } from "@expo/vector-icons";
 import { Stack, useRouter } from "expo-router";
 import React from "react";
-import { TouchableOpacity } from "react-native";
+import CommonHeader from "@/components/CommonHeader/CommonHeader";
 
 export default function OnboardSurveyLayout() {
   const { currentStep, prevStep } = useOnboardStepStore();
@@ -21,17 +18,8 @@ export default function OnboardSurveyLayout() {
   return (
     <Stack
       screenOptions={{
+        header: () => <CommonHeader onPressIcon={handleBack} isEmpty={currentStep === 1} />,
         headerTitle: "",
-        headerLeft: () => (
-          <TouchableOpacity onPress={handleBack}>
-            <ThemedView>
-              {/*  TODO: 최초 단계 시 스플래시 화면으로 이동 로직 추가 및 아이콘 되돌리기 */}
-              {currentStep > 1 && (
-                <MaterialIcons name={"arrow-back"} size={24} color={Colors.neutral_400} />
-              )}
-            </ThemedView>
-          </TouchableOpacity>
-        ),
       }}
     />
   );

--- a/app/onboard-survey/_layout.tsx
+++ b/app/onboard-survey/_layout.tsx
@@ -19,7 +19,6 @@ export default function OnboardSurveyLayout() {
     <Stack
       screenOptions={{
         header: () => <CommonHeader onPressIcon={handleBack} isEmpty={currentStep === 1} />,
-        headerTitle: "",
       }}
     />
   );

--- a/app/onboard-survey/index.tsx
+++ b/app/onboard-survey/index.tsx
@@ -11,7 +11,7 @@ import BirthYearStep from "@/app/onboard-survey/steps/BirthYearStep";
 import WeightStep from "@/app/onboard-survey/steps/WeightStep";
 import ActivityStep from "@/app/onboard-survey/steps/ActivityStep";
 import indexStyles from "@/app/onboard-survey/index.styles";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { View } from "react-native";
 
 const categories = ["성별", "출생연도", "체중", "하루 평균 활동량"];
 
@@ -67,7 +67,7 @@ const OnboardSurvey = () => {
     (currentStep === 1 && !isGenderSelected) || (currentStep === 4 && !isActivitySelected);
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <View style={{ flex: 1 }}>
       <FormProvider {...methods}>
         <ThemedView style={indexStyles.SurveyPageContainer}>
           <SurveyProgressBar currentStep={currentStep} totalSteps={stepComponents.length} />
@@ -86,7 +86,7 @@ const OnboardSurvey = () => {
           </ThemedView>
         </ThemedView>
       </FormProvider>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/app/record-history/_layout.tsx
+++ b/app/record-history/_layout.tsx
@@ -1,0 +1,14 @@
+import { Stack } from "expo-router";
+import React from "react";
+import CommonHeader from "@/components/CommonHeader/CommonHeader";
+
+export default function RecordHistoryLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        header: () => <CommonHeader />,
+        headerTitle: "",
+      }}
+    />
+  );
+}

--- a/app/record-history/_layout.tsx
+++ b/app/record-history/_layout.tsx
@@ -6,8 +6,7 @@ export default function RecordHistoryLayout() {
   return (
     <Stack
       screenOptions={{
-        header: () => <CommonHeader />,
-        headerTitle: "",
+        header: () => <CommonHeader title={"지난 섭취 기록"} />,
       }}
     />
   );

--- a/app/record-history/components/AddPastRecord.styles.ts
+++ b/app/record-history/components/AddPastRecord.styles.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from "react-native";
+import { commonStyles } from "@/components/common.styles";
+import { horizontalScale } from "@/libs/utils/scaling";
+
+export const addPastRecordStyles = StyleSheet.create({
+  timeModeHeader: {
+    ...commonStyles.flexRow,
+    gap: horizontalScale(16),
+    alignItems: "center",
+  },
+});

--- a/app/record-history/components/AddPastRecord.styles.ts
+++ b/app/record-history/components/AddPastRecord.styles.ts
@@ -1,8 +1,11 @@
 import { StyleSheet } from "react-native";
 import { commonStyles } from "@/components/common.styles";
-import { horizontalScale } from "@/libs/utils/scaling";
+import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
 
 const addPastRecordStyles = StyleSheet.create({
+  bottomSheetContainer: {
+    gap: verticalScale(24),
+  },
   timeModeHeader: {
     ...commonStyles.flexRow,
     gap: horizontalScale(16),

--- a/app/record-history/components/AddPastRecord.styles.ts
+++ b/app/record-history/components/AddPastRecord.styles.ts
@@ -2,10 +2,12 @@ import { StyleSheet } from "react-native";
 import { commonStyles } from "@/components/common.styles";
 import { horizontalScale } from "@/libs/utils/scaling";
 
-export const addPastRecordStyles = StyleSheet.create({
+const addPastRecordStyles = StyleSheet.create({
   timeModeHeader: {
     ...commonStyles.flexRow,
     gap: horizontalScale(16),
     alignItems: "center",
   },
 });
+
+export default addPastRecordStyles;

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -1,0 +1,95 @@
+import addNewRecordStyles from "@/app/(tabs)/components/AddNewRecord.styles";
+import { commonStyles } from "@/components/common.styles";
+import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
+import { CustomTab, TabType } from "@/components/CustomTab";
+import React, { useState } from "react";
+import { TouchableOpacity, View } from "react-native";
+import CustomSlider from "@/components/CustomSlider/CustomSlider";
+import { BN1, LN1 } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import CustomButton from "@/components/CustomButton/CustomButton";
+import { useBeverageStore } from "@/stores/beverageStore";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { addPastRecordStyles } from "@/app/record-history/components/AddPastRecord.styles";
+
+interface addNewRecordProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
+  const [currentTab, setCurrentTab] = useState<TabType>("물");
+  const [currentVal, setCurrentVal] = useState(500);
+  const [timeVal, setTimeVal] = useState(0);
+  const [addTimeMode, setAddTimeMode] = useState(false);
+  const { currentIndex } = useBeverageStore();
+
+  const setTimeMode = () => {
+    // TODO: 음료량 기록 API 연동 시 삭제 + 연동하기
+    setAddTimeMode(true);
+  };
+
+  const addTime = () => {
+    onClose();
+  };
+
+  const goBack = () => {
+    setAddTimeMode(false);
+  };
+
+  return (
+    <CustomBottomSheet isOpen={isOpen} onClose={onClose}>
+      {!addTimeMode ? (
+        <View style={addNewRecordStyles.bottomSheetContainer}>
+          <View style={commonStyles.flexRow}>
+            <CustomTab
+              selectedTab={currentTab}
+              onSelectTab={(tab) => setCurrentTab(tab)}
+              visibleTabs={["물", "커피", "녹차"]}
+            />
+          </View>
+
+          <View style={addNewRecordStyles.header}>
+            <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
+              마신 양을 얼마나 추가할까요?
+            </BN1>
+
+            <View style={addNewRecordStyles.inputMeasurement}>
+              <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
+                {currentVal}
+              </BN1>
+              <LN1 lightColor={Colors.neutral_400}>ml</LN1>
+            </View>
+          </View>
+
+          <CustomSlider
+            sliderVal={currentVal}
+            onValueChange={(val) => setCurrentVal(val[0])}
+            step={50}
+            animationType={"spring"}
+            maximumValue={1000}
+            minimumValue={0}
+          />
+
+          <CustomButton
+            title={"시간 추가"}
+            textStyle={{ fontWeight: "bold" }}
+            onPress={setTimeMode}
+          />
+        </View>
+      ) : (
+        <View style={addNewRecordStyles.bottomSheetContainer}>
+          <View style={addPastRecordStyles.timeModeHeader}>
+            <TouchableOpacity onPress={goBack}>
+              <MaterialIcons name={"arrow-back"} size={16} color={Colors.neutral_400} />
+            </TouchableOpacity>
+            <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
+          </View>
+          <CustomButton title={"완료"} textStyle={{ fontWeight: "bold" }} onPress={addTime} />
+        </View>
+      )}
+    </CustomBottomSheet>
+  );
+};
+
+export default AddNewRecord;

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -1,4 +1,3 @@
-import addNewRecordStyles from "@/app/(tabs)/components/AddNewRecord.styles";
 import { commonStyles } from "@/components/common.styles";
 import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
 import CustomButton from "@/components/CustomButton/CustomButton";
@@ -48,7 +47,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
   return (
     <CustomBottomSheet isOpen={isOpen} onClose={handleClose}>
       {!addTimeMode ? (
-        <View style={addNewRecordStyles.bottomSheetContainer}>
+        <View style={addPastRecordStyles.bottomSheetContainer}>
           <View style={commonStyles.flexRow}>
             <CustomTab
               selectedTab={currentTab}
@@ -66,7 +65,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
           />
         </View>
       ) : (
-        <View style={addNewRecordStyles.bottomSheetContainer}>
+        <View style={addPastRecordStyles.bottomSheetContainer}>
           <View style={addPastRecordStyles.timeModeHeader}>
             <TouchableOpacity onPress={goBack}>
               <MaterialIcons

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -1,5 +1,4 @@
 import addNewRecordStyles from "@/app/(tabs)/components/AddNewRecord.styles";
-import { addPastRecordStyles } from "@/app/record-history/components/AddPastRecord.styles";
 import { commonStyles } from "@/components/common.styles";
 import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
 import CustomButton from "@/components/CustomButton/CustomButton";
@@ -11,6 +10,7 @@ import React, { useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
 import RecordTimePickerSection from "@/components/CustomBottomSheet/RecordTimePickerSection";
+import addPastRecordStyles from "@/app/record-history/components/AddPastRecord.styles";
 
 interface addNewRecordProps {
   isOpen: boolean;

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -1,86 +1,58 @@
-import { commonStyles } from "@/components/common.styles";
 import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
-import CustomButton from "@/components/CustomButton/CustomButton";
-import { CustomTab, TabType } from "@/components/CustomTab";
-import { BN1 } from "@/components/ThemedText";
-import { Colors } from "@/constants/Colors";
-import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import React, { useState } from "react";
-import { TouchableOpacity, View } from "react-native";
-import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
-import RecordTimePickerSection from "@/components/CustomBottomSheet/RecordTimePickerSection";
-import addPastRecordStyles from "@/app/record-history/components/AddPastRecord.styles";
-import { verticalScale } from "@/libs/utils/scaling";
+import React from "react";
+import { useAddPastRecord } from "../hooks/useAddPastRecord";
+import AmountStep from "./AmountStep";
+import TimeStep from "./TimeStep";
 
-interface addNewRecordProps {
+interface AddNewRecordProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
-  const [currentTab, setCurrentTab] = useState<TabType>("물");
-  const [currentVal, setCurrentVal] = useState(500);
-  const [addTimeMode, setAddTimeMode] = useState(false);
-  const [selectedDate, setSelectedDate] = useState(new Date());
+const AddNewRecord: React.FC<AddNewRecordProps> = ({ isOpen, onClose }) => {
+  const {
+    currentTab,
+    setCurrentTab,
+    addTimeMode,
+    currentVal,
+    selectedDate,
+    setCurrentVal,
+    setSelectedDate,
+    handleSubmit,
+    onSubmit,
+    setTimeMode,
+    goBack,
+    handleClose,
+  } = useAddPastRecord();
 
-  const setTimeMode = () => {
-    // TODO: 음료량 기록 API 연동 시 삭제 + 연동하기
-    setAddTimeMode(true);
+  const handleCloseModal = () => {
+    handleClose(onClose);
   };
 
-  const addTime = () => {
-    // TODO: 완료 시 submit API 연동
-    onClose();
-  };
-
-  const goBack = () => {
-    setAddTimeMode(false);
-  };
-
-  const handleClose = () => {
-    // 기존 값은 유지, setTimeMode 만 false 처리
-    // TODO: 이 부분에 대한 로직 논의
-    setAddTimeMode(false);
-    onClose();
+  const handleSubmitForm = () => {
+    handleSubmit((data: any) => {
+      onSubmit(data);
+      onClose();
+    })();
   };
 
   return (
-    <CustomBottomSheet isOpen={isOpen} onClose={handleClose}>
+    <CustomBottomSheet isOpen={isOpen} onClose={handleCloseModal}>
       {!addTimeMode ? (
-        <View style={addPastRecordStyles.bottomSheetContainer}>
-          <View style={commonStyles.flexRow}>
-            <CustomTab
-              selectedTab={currentTab}
-              onSelectTab={(tab) => setCurrentTab(tab)}
-              visibleTabs={["물", "커피", "녹차"]}
-            />
-          </View>
-
-          <RecordAmountSection currentVal={currentVal} setCurrentVal={setCurrentVal} />
-
-          <CustomButton
-            title={"시간 추가"}
-            textStyle={{ fontWeight: "bold" }}
-            onPress={setTimeMode}
-          />
-        </View>
+        <AmountStep
+          currentTab={currentTab}
+          onSelectTab={setCurrentTab}
+          currentVal={currentVal}
+          setCurrentVal={setCurrentVal}
+          onNext={setTimeMode}
+        />
       ) : (
-        <View style={addPastRecordStyles.bottomSheetContainer}>
-          <View style={addPastRecordStyles.timeModeHeader}>
-            <TouchableOpacity onPress={goBack}>
-              <MaterialIcons
-                name={"arrow-back"}
-                size={verticalScale(24)}
-                color={Colors.neutral_400}
-              />
-            </TouchableOpacity>
-            <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
-          </View>
-
-          <RecordTimePickerSection value={selectedDate} onChange={setSelectedDate} />
-
-          <CustomButton title={"완료"} textStyle={{ fontWeight: "bold" }} onPress={addTime} />
-        </View>
+        <TimeStep
+          selectedDate={selectedDate}
+          setSelectedDate={setSelectedDate}
+          onBack={goBack}
+          onSubmit={handleSubmitForm}
+        />
       )}
     </CustomBottomSheet>
   );

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -29,6 +29,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
   };
 
   const addTime = () => {
+    // TODO: 완료 시 submit API 연동
     onClose();
   };
 
@@ -36,8 +37,15 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
     setAddTimeMode(false);
   };
 
+  const handleClose = () => {
+    // 기존 값은 유지, setTimeMode 만 false 처리
+    // TODO: 이 부분에 대한 로직 논의
+    setAddTimeMode(false);
+    onClose();
+  };
+
   return (
-    <CustomBottomSheet isOpen={isOpen} onClose={onClose}>
+    <CustomBottomSheet isOpen={isOpen} onClose={handleClose}>
       {!addTimeMode ? (
         <View style={addNewRecordStyles.bottomSheetContainer}>
           <View style={commonStyles.flexRow}>

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -3,14 +3,14 @@ import { addPastRecordStyles } from "@/app/record-history/components/AddPastReco
 import { commonStyles } from "@/components/common.styles";
 import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
 import CustomButton from "@/components/CustomButton/CustomButton";
-import CustomSlider from "@/components/CustomSlider/CustomSlider";
 import { CustomTab, TabType } from "@/components/CustomTab";
-import { BN1, LN1 } from "@/components/ThemedText";
+import { BN1 } from "@/components/ThemedText";
 import { Colors } from "@/constants/Colors";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import React, { useState } from "react";
 import { TouchableOpacity, View } from "react-native";
-import WheelPicker from "react-native-wheel-picker-expo";
+import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
+import RecordTimePickerSection from "@/components/CustomBottomSheet/RecordTimePickerSection";
 
 interface addNewRecordProps {
   isOpen: boolean;
@@ -21,31 +21,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
   const [currentTab, setCurrentTab] = useState<TabType>("물");
   const [currentVal, setCurrentVal] = useState(500);
   const [addTimeMode, setAddTimeMode] = useState(false);
-
-  const ampmOptions = [
-    { label: "오전", value: "AM" },
-    { label: "오후", value: "PM" },
-  ];
-  const hourOptions = Array.from({ length: 12 }, (_, i) => ({
-    label: String(i + 1),
-    value: String(i + 1),
-  }));
-  const minuteOptions = Array.from({ length: 60 }, (_, i) => ({
-    label: i.toString().padStart(2, "0"),
-    value: String(i),
-  }));
-
-  // 현재 시간 계산
-  const now = new Date();
-  const nowHour24 = now.getHours();
-  const nowMinute = now.getMinutes();
-  const initialAmpm = nowHour24 < 12 ? "AM" : "PM";
-  const initialHour = (nowHour24 % 12 || 12).toString();
-  const initialMinute = nowMinute.toString().padStart(2, "0");
-
-  const [ampm, setAmpm] = useState(initialAmpm);
-  const [hour, setHour] = useState(initialHour);
-  const [minute, setMinute] = useState(initialMinute);
+  const [selectedDate, setSelectedDate] = useState(new Date());
 
   const setTimeMode = () => {
     // TODO: 음료량 기록 API 연동 시 삭제 + 연동하기
@@ -72,27 +48,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
             />
           </View>
 
-          <View style={addNewRecordStyles.header}>
-            <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
-              마신 양을 얼마나 추가할까요?
-            </BN1>
-
-            <View style={addNewRecordStyles.inputMeasurement}>
-              <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
-                {currentVal}
-              </BN1>
-              <LN1 lightColor={Colors.neutral_400}>ml</LN1>
-            </View>
-          </View>
-
-          <CustomSlider
-            sliderVal={currentVal}
-            onValueChange={(val) => setCurrentVal(val[0])}
-            step={50}
-            animationType={"spring"}
-            maximumValue={1000}
-            minimumValue={0}
-          />
+          <RecordAmountSection currentVal={currentVal} setCurrentVal={setCurrentVal} />
 
           <CustomButton
             title={"시간 추가"}
@@ -109,38 +65,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
             <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
           </View>
 
-          <View
-            style={{
-              flexDirection: "row",
-              justifyContent: "center",
-              alignItems: "center",
-            }}
-          >
-            <WheelPicker
-              height={172}
-              width={80}
-              items={ampmOptions}
-              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
-              initialSelectedIndex={ampm === "AM" ? 0 : 1}
-              onChange={({ item }) => setAmpm(item.value)}
-            />
-            <WheelPicker
-              height={172}
-              width={80}
-              items={hourOptions}
-              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
-              initialSelectedIndex={Number(hour) - 1}
-              onChange={({ item }) => setHour(item.value)}
-            />
-            <WheelPicker
-              height={172}
-              width={80}
-              items={minuteOptions}
-              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
-              initialSelectedIndex={Number(minute)}
-              onChange={({ item }) => setMinute(item.value)}
-            />
-          </View>
+          <RecordTimePickerSection value={selectedDate} onChange={setSelectedDate} />
 
           <CustomButton title={"완료"} textStyle={{ fontWeight: "bold" }} onPress={addTime} />
         </View>

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -1,16 +1,16 @@
 import addNewRecordStyles from "@/app/(tabs)/components/AddNewRecord.styles";
+import { addPastRecordStyles } from "@/app/record-history/components/AddPastRecord.styles";
 import { commonStyles } from "@/components/common.styles";
 import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
-import { CustomTab, TabType } from "@/components/CustomTab";
-import React, { useState } from "react";
-import { TouchableOpacity, View } from "react-native";
+import CustomButton from "@/components/CustomButton/CustomButton";
 import CustomSlider from "@/components/CustomSlider/CustomSlider";
+import { CustomTab, TabType } from "@/components/CustomTab";
 import { BN1, LN1 } from "@/components/ThemedText";
 import { Colors } from "@/constants/Colors";
-import CustomButton from "@/components/CustomButton/CustomButton";
-import { useBeverageStore } from "@/stores/beverageStore";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import { addPastRecordStyles } from "@/app/record-history/components/AddPastRecord.styles";
+import React, { useState } from "react";
+import { TouchableOpacity, View } from "react-native";
+import WheelPicker from "react-native-wheel-picker-expo";
 
 interface addNewRecordProps {
   isOpen: boolean;
@@ -20,9 +20,32 @@ interface addNewRecordProps {
 const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
   const [currentTab, setCurrentTab] = useState<TabType>("물");
   const [currentVal, setCurrentVal] = useState(500);
-  const [timeVal, setTimeVal] = useState(0);
   const [addTimeMode, setAddTimeMode] = useState(false);
-  const { currentIndex } = useBeverageStore();
+
+  const ampmOptions = [
+    { label: "오전", value: "AM" },
+    { label: "오후", value: "PM" },
+  ];
+  const hourOptions = Array.from({ length: 12 }, (_, i) => ({
+    label: String(i + 1),
+    value: String(i + 1),
+  }));
+  const minuteOptions = Array.from({ length: 60 }, (_, i) => ({
+    label: i.toString().padStart(2, "0"),
+    value: String(i),
+  }));
+
+  // 현재 시간 계산
+  const now = new Date();
+  const nowHour24 = now.getHours();
+  const nowMinute = now.getMinutes();
+  const initialAmpm = nowHour24 < 12 ? "AM" : "PM";
+  const initialHour = (nowHour24 % 12 || 12).toString();
+  const initialMinute = nowMinute.toString().padStart(2, "0");
+
+  const [ampm, setAmpm] = useState(initialAmpm);
+  const [hour, setHour] = useState(initialHour);
+  const [minute, setMinute] = useState(initialMinute);
 
   const setTimeMode = () => {
     // TODO: 음료량 기록 API 연동 시 삭제 + 연동하기
@@ -85,6 +108,40 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
             </TouchableOpacity>
             <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
           </View>
+
+          <View
+            style={{
+              flexDirection: "row",
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
+            <WheelPicker
+              height={172}
+              width={80}
+              items={ampmOptions}
+              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+              initialSelectedIndex={ampm === "AM" ? 0 : 1}
+              onChange={({ item }) => setAmpm(item.value)}
+            />
+            <WheelPicker
+              height={172}
+              width={80}
+              items={hourOptions}
+              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+              initialSelectedIndex={Number(hour) - 1}
+              onChange={({ item }) => setHour(item.value)}
+            />
+            <WheelPicker
+              height={172}
+              width={80}
+              items={minuteOptions}
+              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+              initialSelectedIndex={Number(minute)}
+              onChange={({ item }) => setMinute(item.value)}
+            />
+          </View>
+
           <CustomButton title={"완료"} textStyle={{ fontWeight: "bold" }} onPress={addTime} />
         </View>
       )}

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -11,6 +11,7 @@ import { TouchableOpacity, View } from "react-native";
 import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
 import RecordTimePickerSection from "@/components/CustomBottomSheet/RecordTimePickerSection";
 import addPastRecordStyles from "@/app/record-history/components/AddPastRecord.styles";
+import { verticalScale } from "@/libs/utils/scaling";
 
 interface addNewRecordProps {
   isOpen: boolean;
@@ -68,7 +69,11 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
         <View style={addNewRecordStyles.bottomSheetContainer}>
           <View style={addPastRecordStyles.timeModeHeader}>
             <TouchableOpacity onPress={goBack}>
-              <MaterialIcons name={"arrow-back"} size={16} color={Colors.neutral_400} />
+              <MaterialIcons
+                name={"arrow-back"}
+                size={verticalScale(24)}
+                color={Colors.neutral_400}
+              />
             </TouchableOpacity>
             <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
           </View>

--- a/app/record-history/components/AmountStep.tsx
+++ b/app/record-history/components/AmountStep.tsx
@@ -1,0 +1,45 @@
+import { commonStyles } from "@/components/common.styles";
+import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
+import CustomButton from "@/components/CustomButton/CustomButton";
+import { CustomTab, TabType } from "@/components/CustomTab";
+import React from "react";
+import { View } from "react-native";
+import addPastRecordStyles from "./AddPastRecord.styles";
+
+interface AmountStepProps {
+  currentTab: TabType;
+  onSelectTab: (tab: TabType) => void;
+  currentVal: number;
+  setCurrentVal: (value: number) => void;
+  onNext: () => void;
+}
+
+const AmountStep: React.FC<AmountStepProps> = ({
+  currentTab,
+  onSelectTab,
+  currentVal,
+  setCurrentVal,
+  onNext,
+}) => {
+  return (
+    <View style={addPastRecordStyles.bottomSheetContainer}>
+      <View style={commonStyles.flexRow}>
+        <CustomTab
+          selectedTab={currentTab}
+          onSelectTab={onSelectTab}
+          visibleTabs={["물", "커피", "녹차"]}
+        />
+      </View>
+
+      <RecordAmountSection currentVal={currentVal} setCurrentVal={setCurrentVal} />
+
+      <CustomButton
+        title={"시간 추가"}
+        textStyle={{ fontWeight: "bold" }}
+        onPress={onNext}
+      />
+    </View>
+  );
+};
+
+export default AmountStep;

--- a/app/record-history/components/TimeStep.tsx
+++ b/app/record-history/components/TimeStep.tsx
@@ -1,0 +1,48 @@
+import RecordTimePickerSection from "@/components/CustomBottomSheet/RecordTimePickerSection";
+import CustomButton from "@/components/CustomButton/CustomButton";
+import { BN1 } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import { verticalScale } from "@/libs/utils/scaling";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import React from "react";
+import { TouchableOpacity, View } from "react-native";
+import addPastRecordStyles from "./AddPastRecord.styles";
+
+interface TimeStepProps {
+  selectedDate: Date;
+  setSelectedDate: (date: Date) => void;
+  onBack: () => void;
+  onSubmit: () => void;
+}
+
+const TimeStep: React.FC<TimeStepProps> = ({
+  selectedDate,
+  setSelectedDate,
+  onBack,
+  onSubmit,
+}) => {
+  return (
+    <View style={addPastRecordStyles.bottomSheetContainer}>
+      <View style={addPastRecordStyles.timeModeHeader}>
+        <TouchableOpacity onPress={onBack}>
+          <MaterialIcons
+            name={"arrow-back"}
+            size={verticalScale(24)}
+            color={Colors.neutral_400}
+          />
+        </TouchableOpacity>
+        <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
+      </View>
+
+      <RecordTimePickerSection value={selectedDate} onChange={setSelectedDate} />
+
+      <CustomButton
+        title={"완료"}
+        textStyle={{ fontWeight: "bold" }}
+        onPress={onSubmit}
+      />
+    </View>
+  );
+};
+
+export default TimeStep;

--- a/app/record-history/constants/drinkMapping.ts
+++ b/app/record-history/constants/drinkMapping.ts
@@ -1,0 +1,35 @@
+import { TabType } from "@/components/CustomTab";
+
+// 탭에 따른 drinkId 매핑
+export const drinkIdMap: Record<string, number> = {
+  All: 0,
+  Water: 1,
+  Coffee: 2,
+  GreenTea: 3,
+  Cola: 4,
+};
+
+// 한글 탭을 영어 키로 매핑
+export const tabToKeyMap = (tab: string): string => {
+  switch (tab) {
+    case "전체":
+      return "All";
+    case "물":
+      return "Water";
+    case "커피":
+      return "Coffee";
+    case "녹차":
+      return "GreenTea";
+    case "콜라":
+      return "Cola";
+    default:
+      return "Water";
+  }
+};
+
+// drinkId 가져오기 헬퍼 함수
+export const getDrinkId = (tab: TabType): number => {
+  return drinkIdMap[tabToKeyMap(tab)];
+};
+
+export default drinkIdMap;

--- a/app/record-history/hooks/useAddPastRecord.ts
+++ b/app/record-history/hooks/useAddPastRecord.ts
@@ -1,0 +1,97 @@
+import { TabType } from "@/components/CustomTab";
+import { useFormData } from "./useFormData";
+import { useStepManager } from "./useStepManager";
+import { useSubmitHandler } from "./useSubmitHandler";
+
+export interface UseAddPastRecordReturn {
+  // Form state
+  currentTab: TabType;
+  setCurrentTab: (tab: TabType) => void;
+  addTimeMode: boolean;
+
+  // Form values
+  currentVal: number;
+  selectedDate: Date;
+  setCurrentVal: (value: number) => void;
+  setSelectedDate: (date: Date) => void;
+
+  // Form methods
+  handleSubmit: (onSubmit: (data: any) => void) => (e?: React.BaseSyntheticEvent) => Promise<void>;
+  onSubmit: (data: any) => void;
+  reset: () => void;
+
+  // Actions
+  setTimeMode: () => void;
+  goBack: () => void;
+  handleClose: (onClose: () => void) => void;
+}
+
+export const useAddPastRecord = (): UseAddPastRecordReturn => {
+  const {
+    handleSubmit,
+    reset: resetForm,
+    currentVal,
+    selectedDate,
+    setCurrentVal,
+    setSelectedDate,
+    updateDrinkId,
+  } = useFormData();
+
+  const { currentTab, setCurrentTab, addTimeMode, goToTimeStep, goBackToAmountStep, resetSteps } =
+    useStepManager();
+
+  const { onSubmit: submitData } = useSubmitHandler();
+
+  const setTimeMode = () => {
+    const drinkId = goToTimeStep();
+    updateDrinkId(drinkId);
+  };
+
+  const onSubmit = (data: any) => {
+    submitData(data);
+    // 폼 초기화 및 스텝 리셋
+    resetForm();
+    resetSteps();
+  };
+
+  const goBack = () => {
+    goBackToAmountStep();
+  };
+
+  const handleClose = (onClose: () => void) => {
+    // 폼 초기화 및 모달 닫기
+    resetForm();
+    resetSteps();
+    onClose();
+  };
+
+  const reset = () => {
+    resetForm();
+    resetSteps();
+  };
+
+  return {
+    // Form state
+    currentTab,
+    setCurrentTab,
+    addTimeMode,
+
+    // Form values
+    currentVal,
+    selectedDate,
+    setCurrentVal,
+    setSelectedDate,
+
+    // Form methods
+    handleSubmit,
+    onSubmit,
+    reset,
+
+    // Actions
+    setTimeMode,
+    goBack,
+    handleClose,
+  };
+};
+
+export default useAddPastRecord;

--- a/app/record-history/hooks/useFormData.ts
+++ b/app/record-history/hooks/useFormData.ts
@@ -1,0 +1,45 @@
+import { useForm } from "react-hook-form";
+import { getDrinkId } from "../constants/drinkMapping";
+
+interface FormData {
+  drinkId: number;
+  amount: number;
+  drinkAt: string;
+}
+
+export const useFormData = () => {
+  const { handleSubmit, setValue, watch, reset } = useForm<FormData>({
+    defaultValues: {
+      drinkId: getDrinkId("물"),
+      amount: 500,
+      drinkAt: new Date().toISOString(),
+    },
+  });
+
+  const currentVal = watch("amount");
+  const selectedDate = new Date(watch("drinkAt"));
+
+  const setCurrentVal = (value: number) => {
+    setValue("amount", value);
+  };
+
+  const setSelectedDate = (date: Date) => {
+    setValue("drinkAt", date.toISOString());
+  };
+
+  const updateDrinkId = (drinkId: number) => {
+    setValue("drinkId", drinkId);
+  };
+
+  return {
+    handleSubmit,
+    reset,
+    currentVal,
+    selectedDate,
+    setCurrentVal,
+    setSelectedDate,
+    updateDrinkId,
+  };
+};
+
+export default useFormData;

--- a/app/record-history/hooks/useStepManager.ts
+++ b/app/record-history/hooks/useStepManager.ts
@@ -1,0 +1,33 @@
+import { TabType } from "@/components/CustomTab";
+import { useState } from "react";
+import { getDrinkId } from "../constants/drinkMapping";
+
+export const useStepManager = () => {
+  const [currentTab, setCurrentTab] = useState<TabType>("물");
+  const [addTimeMode, setAddTimeMode] = useState(false);
+
+  const goToTimeStep = () => {
+    setAddTimeMode(true);
+    return getDrinkId(currentTab);
+  };
+
+  const goBackToAmountStep = () => {
+    setAddTimeMode(false);
+  };
+
+  const resetSteps = () => {
+    setCurrentTab("물");
+    setAddTimeMode(false);
+  };
+
+  return {
+    currentTab,
+    setCurrentTab,
+    addTimeMode,
+    goToTimeStep,
+    goBackToAmountStep,
+    resetSteps,
+  };
+};
+
+export default useStepManager;

--- a/app/record-history/hooks/useSubmitHandler.ts
+++ b/app/record-history/hooks/useSubmitHandler.ts
@@ -1,0 +1,27 @@
+interface FormData {
+  drinkId: number;
+  amount: number;
+  drinkAt: string;
+}
+
+export const useSubmitHandler = () => {
+  const onSubmit = (data: FormData) => {
+    // 최종 데이터 구성
+    const submitData = {
+      drinkId: data.drinkId,
+      amount: data.amount,
+      drinkAt: data.drinkAt,
+    };
+
+    console.log("Submit Data:", submitData);
+    // TODO: API 연동 시 여기에 API 호출 로직 추가
+
+    return submitData;
+  };
+
+  return {
+    onSubmit,
+  };
+};
+
+export default useSubmitHandler;

--- a/app/record-history/index.styles.ts
+++ b/app/record-history/index.styles.ts
@@ -1,0 +1,5 @@
+import { StyleSheet } from "react-native";
+
+export const recordHistoryStyles = StyleSheet.create({});
+
+export default recordHistoryStyles;

--- a/app/record-history/index.tsx
+++ b/app/record-history/index.tsx
@@ -1,11 +1,17 @@
 import React from "react";
-import { Text, View } from "react-native";
+import { commonStyles } from "@/components/common.styles";
+import { ThemedView } from "@/components/ThemedView";
+import CustomButton from "@/components/CustomButton/CustomButton";
 
 const RecordHistory = () => {
   return (
-    <View>
-      <Text>RecordHistory</Text>
-    </View>
+    <ThemedView style={commonStyles.pageContainer}>
+      <CustomButton
+        title={"지난 기록 추가"}
+        variant={"secondary"}
+        textStyle={{ fontWeight: "bold" }}
+      />
+    </ThemedView>
   );
 };
 

--- a/app/record-history/index.tsx
+++ b/app/record-history/index.tsx
@@ -1,16 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 import { commonStyles } from "@/components/common.styles";
 import { ThemedView } from "@/components/ThemedView";
 import CustomButton from "@/components/CustomButton/CustomButton";
+import AddPastRecord from "@/app/record-history/components/AddPastRecord";
 
 const RecordHistory = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
     <ThemedView style={commonStyles.pageContainer}>
       <CustomButton
         title={"지난 기록 추가"}
         variant={"secondary"}
         textStyle={{ fontWeight: "bold" }}
+        onPress={() => setIsModalOpen(true)}
       />
+      <AddPastRecord isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
     </ThemedView>
   );
 };

--- a/app/record-history/index.tsx
+++ b/app/record-history/index.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Text, View } from "react-native";
+
+const RecordHistory = () => {
+  return (
+    <View>
+      <Text>RecordHistory</Text>
+    </View>
+  );
+};
+
+export default RecordHistory;

--- a/components/CommonHeader/CommonHeader.styles.ts
+++ b/components/CommonHeader/CommonHeader.styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from "react-native";
+import { verticalScale } from "@/libs/utils/scaling";
+
+export const commonHeaderStyles = StyleSheet.create({
+  commonHeaderContainer: {
+    height: verticalScale(56),
+    justifyContent: "center",
+  },
+});

--- a/components/CommonHeader/CommonHeader.styles.ts
+++ b/components/CommonHeader/CommonHeader.styles.ts
@@ -1,13 +1,15 @@
 import { StyleSheet } from "react-native";
-import { paddingScale, verticalScale } from "@/libs/utils/scaling";
+import { horizontalScale, paddingScale, verticalScale } from "@/libs/utils/scaling";
 
 export const commonHeaderStyles = StyleSheet.create({
   emptyHeader: {
     height: verticalScale(56),
   },
   commonHeaderContainer: {
+    flexDirection: "row",
     height: verticalScale(56),
-    justifyContent: "center",
+    gap: horizontalScale(16),
+    alignItems: "center",
     ...paddingScale(16),
   },
 });

--- a/components/CommonHeader/CommonHeader.styles.ts
+++ b/components/CommonHeader/CommonHeader.styles.ts
@@ -1,9 +1,13 @@
 import { StyleSheet } from "react-native";
-import { verticalScale } from "@/libs/utils/scaling";
+import { paddingScale, verticalScale } from "@/libs/utils/scaling";
 
 export const commonHeaderStyles = StyleSheet.create({
+  emptyHeader: {
+    height: verticalScale(56),
+  },
   commonHeaderContainer: {
     height: verticalScale(56),
     justifyContent: "center",
+    ...paddingScale(16),
   },
 });

--- a/components/CommonHeader/CommonHeader.tsx
+++ b/components/CommonHeader/CommonHeader.tsx
@@ -1,0 +1,32 @@
+import React, { ComponentProps } from "react";
+import { TouchableOpacity, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { MaterialIcons } from "@expo/vector-icons";
+import { Colors } from "@/constants/Colors";
+import { commonHeaderStyles } from "@/components/CommonHeader/CommonHeader.styles";
+import { useRouter } from "expo-router";
+
+interface CommonHeaderProps {
+  iconName?: ComponentProps<typeof MaterialIcons>["name"];
+  onPressIcon?: () => void;
+}
+
+const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon }) => {
+  const router = useRouter();
+
+  const goBack = () => {
+    router.back();
+  };
+
+  return (
+    <SafeAreaView>
+      <View style={commonHeaderStyles.commonHeaderContainer}>
+        <TouchableOpacity onPress={onPressIcon ?? goBack}>
+          <MaterialIcons name={iconName ?? "arrow-back"} size={24} color={Colors.neutral_400} />
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default CommonHeader;

--- a/components/CommonHeader/CommonHeader.tsx
+++ b/components/CommonHeader/CommonHeader.tsx
@@ -9,9 +9,10 @@ import { useRouter } from "expo-router";
 interface CommonHeaderProps {
   iconName?: ComponentProps<typeof MaterialIcons>["name"];
   onPressIcon?: () => void;
+  isEmpty?: boolean;
 }
 
-const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon }) => {
+const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon, isEmpty = false }) => {
   const router = useRouter();
 
   const goBack = () => {
@@ -19,12 +20,16 @@ const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon }) =>
   };
 
   return (
-    <SafeAreaView>
-      <View style={commonHeaderStyles.commonHeaderContainer}>
-        <TouchableOpacity onPress={onPressIcon ?? goBack}>
-          <MaterialIcons name={iconName ?? "arrow-back"} size={24} color={Colors.neutral_400} />
-        </TouchableOpacity>
-      </View>
+    <SafeAreaView style={{ backgroundColor: "white" }}>
+      {isEmpty ? (
+        <View style={commonHeaderStyles.emptyHeader} />
+      ) : (
+        <View style={commonHeaderStyles.commonHeaderContainer}>
+          <TouchableOpacity onPress={onPressIcon ?? goBack}>
+            <MaterialIcons name={iconName ?? "arrow-back"} size={24} color={Colors.neutral_400} />
+          </TouchableOpacity>
+        </View>
+      )}
     </SafeAreaView>
   );
 };

--- a/components/CommonHeader/CommonHeader.tsx
+++ b/components/CommonHeader/CommonHeader.tsx
@@ -5,14 +5,23 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { Colors } from "@/constants/Colors";
 import { commonHeaderStyles } from "@/components/CommonHeader/CommonHeader.styles";
 import { useRouter } from "expo-router";
+import { BN1 } from "@/components/ThemedText";
 
 interface CommonHeaderProps {
   iconName?: ComponentProps<typeof MaterialIcons>["name"];
   onPressIcon?: () => void;
   isEmpty?: boolean;
+  title?: string;
+  hasIcon?: boolean;
 }
 
-const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon, isEmpty = false }) => {
+const CommonHeader: React.FC<CommonHeaderProps> = ({
+  iconName,
+  onPressIcon,
+  isEmpty = false,
+  title,
+  hasIcon = true,
+}) => {
   const router = useRouter();
 
   const goBack = () => {
@@ -25,9 +34,16 @@ const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon, isEm
         <View style={commonHeaderStyles.emptyHeader} />
       ) : (
         <View style={commonHeaderStyles.commonHeaderContainer}>
-          <TouchableOpacity onPress={onPressIcon ?? goBack}>
-            <MaterialIcons name={iconName ?? "arrow-back"} size={24} color={Colors.neutral_400} />
-          </TouchableOpacity>
+          {hasIcon && (
+            <TouchableOpacity onPress={onPressIcon ?? goBack}>
+              <MaterialIcons name={iconName ?? "arrow-back"} size={24} color={Colors.neutral_400} />
+            </TouchableOpacity>
+          )}
+          {title && (
+            <BN1 lightColor={Colors.neutral_800} style={{ fontWeight: "bold" }}>
+              {title}
+            </BN1>
+          )}
         </View>
       )}
     </SafeAreaView>

--- a/components/CustomBottomSheet/RecordAmountSection.styles.ts
+++ b/components/CustomBottomSheet/RecordAmountSection.styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from "react-native";
+import { commonStyles } from "@/components/common.styles";
+import { horizontalScale } from "@/libs/utils/scaling";
+
+export const recordAmountSectionStyles = StyleSheet.create({
+  header: {
+    ...commonStyles.flexRow,
+    justifyContent: "space-between",
+  },
+  inputMeasurement: {
+    ...commonStyles.flexRow,
+    gap: horizontalScale(12),
+    alignItems: "center",
+  },
+});

--- a/components/CustomBottomSheet/RecordAmountSection.tsx
+++ b/components/CustomBottomSheet/RecordAmountSection.tsx
@@ -1,0 +1,49 @@
+// components/RecordAmountSection.tsx
+import React, { Fragment } from "react";
+import { View } from "react-native";
+import { BN1, LN1 } from "@/components/ThemedText";
+import CustomSlider from "@/components/CustomSlider/CustomSlider";
+import { Colors } from "@/constants/Colors";
+import { recordAmountSectionStyles } from "@/components/CustomBottomSheet/RecordAmountSection.styles";
+
+interface RecordAmountSectionProps {
+  currentVal: number;
+  setCurrentVal: (val: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+const RecordAmountSection: React.FC<RecordAmountSectionProps> = ({
+  currentVal,
+  setCurrentVal,
+  min = 0,
+  max = 1000,
+  step = 50,
+}) => (
+  <Fragment>
+    <View style={recordAmountSectionStyles.header}>
+      <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
+        마신 양을 얼마나 추가할까요?
+      </BN1>
+
+      <View style={recordAmountSectionStyles.inputMeasurement}>
+        <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
+          {currentVal}
+        </BN1>
+        <LN1 lightColor={Colors.neutral_400}>ml</LN1>
+      </View>
+    </View>
+
+    <CustomSlider
+      sliderVal={currentVal}
+      onValueChange={(val) => setCurrentVal(val[0])}
+      step={step}
+      animationType={"spring"}
+      maximumValue={max}
+      minimumValue={min}
+    />
+  </Fragment>
+);
+
+export default RecordAmountSection;

--- a/components/CustomBottomSheet/RecordAmountSection.tsx
+++ b/components/CustomBottomSheet/RecordAmountSection.tsx
@@ -17,7 +17,7 @@ interface RecordAmountSectionProps {
 const RecordAmountSection: React.FC<RecordAmountSectionProps> = ({
   currentVal,
   setCurrentVal,
-  min = 0,
+  min = 50,
   max = 1000,
   step = 50,
 }) => (

--- a/components/CustomBottomSheet/RecordTimePickerSection.styles.ts
+++ b/components/CustomBottomSheet/RecordTimePickerSection.styles.ts
@@ -1,10 +1,25 @@
 import { StyleSheet } from "react-native";
 import { commonStyles } from "@/components/common.styles";
+import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
+import { Colors } from "@/constants/Colors";
 
 export const recordTimePickerSectionStyles = StyleSheet.create({
   timePickerWrapper: {
     ...commonStyles.flexRow,
     justifyContent: "center",
     alignItems: "center",
+  },
+  wheelPickerSelectedItem: {
+    borderColor: Colors.neutral_200,
+    borderWidth: horizontalScale(1),
+  },
+  timeDot: {
+    height: verticalScale(35),
+    borderColor: Colors.neutral_200,
+    borderTopWidth: horizontalScale(1),
+    borderBottomWidth: horizontalScale(1),
+    flexDirection: "column",
+    verticalAlign: "middle",
+    fontWeight: "bold",
   },
 });

--- a/components/CustomBottomSheet/RecordTimePickerSection.styles.ts
+++ b/components/CustomBottomSheet/RecordTimePickerSection.styles.ts
@@ -1,0 +1,10 @@
+import { StyleSheet } from "react-native";
+import { commonStyles } from "@/components/common.styles";
+
+export const recordTimePickerSectionStyles = StyleSheet.create({
+  timePickerWrapper: {
+    ...commonStyles.flexRow,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});

--- a/components/CustomBottomSheet/RecordTimePickerSection.tsx
+++ b/components/CustomBottomSheet/RecordTimePickerSection.tsx
@@ -1,10 +1,10 @@
-import { Colors } from "@/constants/Colors";
 import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
 import React, { useEffect, useState } from "react";
 import { View } from "react-native";
 import WheelPicker from "react-native-wheel-picker-expo";
 import { combinePickerToDate, splitDateToPicker } from "@/hooks/useDateTimeTransform";
 import { recordTimePickerSectionStyles } from "@/components/CustomBottomSheet/RecordTimePickerSection.styles";
+import { HL1 } from "@/components/ThemedText";
 
 interface RecordTimePickerSectionProps {
   value: Date;
@@ -20,7 +20,7 @@ const RecordTimePickerSection: React.FC<RecordTimePickerSectionProps> = ({ value
     label: String(i + 1),
     value: String(i + 1),
   }));
-  const minuteOptions = Array.from({ length: 60 }, (_, i) => ({
+  const minuteOptions = Array.from({ length: 65 }, (_, i) => ({
     label: i.toString().padStart(2, "0"),
     value: String(i),
   }));
@@ -46,25 +46,29 @@ const RecordTimePickerSection: React.FC<RecordTimePickerSectionProps> = ({ value
     <View style={recordTimePickerSectionStyles.timePickerWrapper}>
       <WheelPicker
         height={verticalScale(172)}
-        width={horizontalScale(75)}
+        width={horizontalScale(65)}
         items={ampmOptions}
-        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        selectedStyle={recordTimePickerSectionStyles.wheelPickerSelectedItem}
         initialSelectedIndex={ampm === "AM" ? 0 : 1}
         onChange={({ item }) => setAmpm(item.value)}
       />
+
       <WheelPicker
         height={verticalScale(172)}
-        width={horizontalScale(75)}
+        width={horizontalScale(65)}
         items={hourOptions}
-        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        selectedStyle={recordTimePickerSectionStyles.wheelPickerSelectedItem}
         initialSelectedIndex={Number(hour) - 1}
         onChange={({ item }) => setHour(item.value)}
       />
+
+      <HL1 style={recordTimePickerSectionStyles.timeDot}>:</HL1>
+
       <WheelPicker
         height={verticalScale(172)}
-        width={horizontalScale(75)}
+        width={horizontalScale(65)}
         items={minuteOptions}
-        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        selectedStyle={recordTimePickerSectionStyles.wheelPickerSelectedItem}
         initialSelectedIndex={Number(minute)}
         onChange={({ item }) => setMinute(item.value)}
       />

--- a/components/CustomBottomSheet/RecordTimePickerSection.tsx
+++ b/components/CustomBottomSheet/RecordTimePickerSection.tsx
@@ -1,0 +1,75 @@
+import { Colors } from "@/constants/Colors";
+import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
+import React, { useEffect, useState } from "react";
+import { View } from "react-native";
+import WheelPicker from "react-native-wheel-picker-expo";
+import { combinePickerToDate, splitDateToPicker } from "@/hooks/useDateTimeTransform";
+import { recordTimePickerSectionStyles } from "@/components/CustomBottomSheet/RecordTimePickerSection.styles";
+
+interface RecordTimePickerSectionProps {
+  value: Date;
+  onChange: (date: Date) => void;
+}
+
+const RecordTimePickerSection: React.FC<RecordTimePickerSectionProps> = ({ value, onChange }) => {
+  const ampmOptions = [
+    { label: "오전", value: "AM" },
+    { label: "오후", value: "PM" },
+  ];
+  const hourOptions = Array.from({ length: 12 }, (_, i) => ({
+    label: String(i + 1),
+    value: String(i + 1),
+  }));
+  const minuteOptions = Array.from({ length: 60 }, (_, i) => ({
+    label: i.toString().padStart(2, "0"),
+    value: String(i),
+  }));
+
+  // value prop이 바뀔 때마다 picker state를 동기화
+  const { ampm: initialAmpm, hour: initialHour, minute: initialMinute } = splitDateToPicker(value);
+  const [ampm, setAmpm] = useState(initialAmpm);
+  const [hour, setHour] = useState(initialHour);
+  const [minute, setMinute] = useState(initialMinute);
+
+  useEffect(() => {
+    setAmpm(initialAmpm);
+    setHour(initialHour);
+    setMinute(initialMinute);
+  }, [value]);
+
+  useEffect(() => {
+    const newDate = combinePickerToDate(value, ampm, hour, minute);
+    onChange(newDate);
+  }, [ampm, hour, minute]);
+
+  return (
+    <View style={recordTimePickerSectionStyles.timePickerWrapper}>
+      <WheelPicker
+        height={verticalScale(172)}
+        width={horizontalScale(75)}
+        items={ampmOptions}
+        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        initialSelectedIndex={ampm === "AM" ? 0 : 1}
+        onChange={({ item }) => setAmpm(item.value)}
+      />
+      <WheelPicker
+        height={verticalScale(172)}
+        width={horizontalScale(75)}
+        items={hourOptions}
+        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        initialSelectedIndex={Number(hour) - 1}
+        onChange={({ item }) => setHour(item.value)}
+      />
+      <WheelPicker
+        height={verticalScale(172)}
+        width={horizontalScale(75)}
+        items={minuteOptions}
+        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        initialSelectedIndex={Number(minute)}
+        onChange={({ item }) => setMinute(item.value)}
+      />
+    </View>
+  );
+};
+
+export default RecordTimePickerSection;

--- a/components/CustomSlider/CustomSlider.tsx
+++ b/components/CustomSlider/CustomSlider.tsx
@@ -27,7 +27,7 @@ interface CustomSliderProps extends Partial<SliderProps> {
 const CustomSlider: React.FC<CustomSliderProps> = ({
   sliderVal,
   onValueChange,
-  trackMarks = [0, 1000],
+  trackMarks = [50, 1000],
   ...props
 }) => {
   const renderTrackMark = (index: number) => <TrackMark value={trackMarks[index]} />;

--- a/components/CustomSlider/TrackMark.tsx
+++ b/components/CustomSlider/TrackMark.tsx
@@ -3,13 +3,14 @@ import { ThemedView } from "@/components/ThemedView";
 import { Colors } from "@/constants/Colors";
 import React from "react";
 import { StyleSheet } from "react-native";
-import { verticalScale } from "@/libs/utils/scaling";
+import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
 
 export const trackMarkStyles = StyleSheet.create({
   StyledThemedView: {
     backgroundColor: "transparent",
     height: verticalScale(80),
     justifyContent: "flex-end",
+    marginLeft: horizontalScale(10),
   },
 });
 

--- a/components/common.styles.ts
+++ b/components/common.styles.ts
@@ -5,6 +5,7 @@ import { StyleSheet } from "react-native";
 export const commonStyles = StyleSheet.create({
   pageContainer: {
     // main 페이지 기준 패딩 적용
+    flex: 1,
     ...paddingScale(8, 16),
   },
   transparentView: {

--- a/hooks/useDateTimeTransform.ts
+++ b/hooks/useDateTimeTransform.ts
@@ -1,0 +1,20 @@
+export function splitDateToPicker(date: Date) {
+  const hour24 = date.getHours();
+  const ampm = hour24 < 12 ? "AM" : "PM";
+  const hour12 = hour24 % 12 || 12;
+  const minute = date.getMinutes();
+  return {
+    ampm,
+    hour: hour12.toString(),
+    minute: minute.toString().padStart(2, "0"),
+  };
+}
+
+export function combinePickerToDate(base: Date, ampm: string, hour: string, minute: string) {
+  let hour24 = Number(hour) % 12;
+  if (ampm === "PM") hour24 += 12;
+  if (ampm === "AM" && hour24 === 12) hour24 = 0;
+  const newDate = new Date(base);
+  newDate.setHours(hour24, Number(minute), 0, 0);
+  return newDate;
+}


### PR DESCRIPTION
## ✅ Done
- 지난 섭취 기록 페이지 기본 뼈대 구성
- 지난 기록 버튼 추가 및 바텀 시트 연동
- 바텀시트 내 마신 양 및 시간 기록 디자인 및 기능 구현
    - react-hook-form 기반 연동 완료 (Swagger 기준 submit 시 데이터 console.log 표시)

## 📝 Note
- 추후 API 연동 작업 시 수정이 필요한 부분들이 있습니다:
    - 사용자 정보 기반으로 한 탭 표시 (현재는 물, 커피, 녹차로 표시)
    - 완료 시 "음료 섭취 기록 추가" API 연동
    - 추후 지난 섭취 기록 리스트 구현 시 해당 리스트에 새롭게 추가되게 조치