### PR TITLE
개인 설정 페이지 기본 뼈대 구현

### DIFF
--- a/app/(settings)/_layout.tsx
+++ b/app/(settings)/_layout.tsx
@@ -1,0 +1,24 @@
+import CommonHeader from "@/components/CommonHeader/CommonHeader";
+import { Stack, usePathname } from "expo-router";
+import React from "react";
+
+export default function SettingsLayout() {
+  const pathname = usePathname();
+
+  const getHeaderTitle = () => {
+    switch (pathname) {
+      case "/login-info":
+        return "로그인 정보";
+      default:
+        return "개인 설정";
+    }
+  };
+
+  return (
+    <Stack
+      screenOptions={{
+        header: () => <CommonHeader title={getHeaderTitle()} />,
+      }}
+    />
+  );
+}

--- a/app/(settings)/components/SettingsListItem.styles.ts
+++ b/app/(settings)/components/SettingsListItem.styles.ts
@@ -1,0 +1,38 @@
+import { StyleSheet } from "react-native";
+import { Colors } from "@/constants/Colors";
+
+const settingsListItemStyles = StyleSheet.create({
+  settingItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 16,
+    paddingHorizontal: 16,
+    backgroundColor: "white",
+    marginBottom: 12,
+    borderRadius: 12,
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: 1,
+    },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  iconContainer: {
+    marginRight: 16,
+  },
+  textContainer: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 16,
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: Colors.neutral_600,
+  },
+});
+
+export default settingsListItemStyles;

--- a/app/(settings)/components/SettingsListItem.styles.ts
+++ b/app/(settings)/components/SettingsListItem.styles.ts
@@ -1,23 +1,11 @@
 import { StyleSheet } from "react-native";
-import { Colors } from "@/constants/Colors";
+import { paddingScale } from "@/libs/utils/scaling";
 
 const settingsListItemStyles = StyleSheet.create({
   settingItem: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: 16,
-    paddingHorizontal: 16,
-    backgroundColor: "white",
-    marginBottom: 12,
-    borderRadius: 12,
-    shadowColor: "#000",
-    shadowOffset: {
-      width: 0,
-      height: 1,
-    },
-    shadowOpacity: 0.1,
-    shadowRadius: 2,
-    elevation: 2,
+    ...paddingScale(12, 4, 12, 12),
   },
   iconContainer: {
     marginRight: 16,
@@ -26,12 +14,7 @@ const settingsListItemStyles = StyleSheet.create({
     flex: 1,
   },
   title: {
-    fontSize: 16,
-    marginBottom: 4,
-  },
-  subtitle: {
-    fontSize: 14,
-    color: Colors.neutral_600,
+    fontWeight: "500",
   },
 });
 

--- a/app/(settings)/components/SettingsListItem.tsx
+++ b/app/(settings)/components/SettingsListItem.tsx
@@ -2,9 +2,10 @@ import React from "react";
 import { TouchableOpacity, View } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 import { Colors } from "@/constants/Colors";
-import { BN1 } from "@/components/ThemedText";
+import { BN2 } from "@/components/ThemedText";
 import settingsListItemStyles from "@/app/(settings)/components/SettingsListItem.styles";
 import { useRouter } from "expo-router";
+import { verticalScale } from "@/libs/utils/scaling";
 
 interface SettingsListItemProps {
   title: string;
@@ -30,16 +31,16 @@ const SettingsListItem: React.FC<SettingsListItemProps> = ({
       style={settingsListItemStyles.settingItem}
       onPress={() => handlePress(route ?? "/(settings)")}
     >
-      <View style={settingsListItemStyles.iconContainer}>{leftIcon}</View>
+      {leftIcon && <View style={settingsListItemStyles.iconContainer}>{leftIcon}</View>}
 
       <View style={settingsListItemStyles.textContainer}>
-        <BN1 style={settingsListItemStyles.title}>{title}</BN1>
+        <BN2 style={settingsListItemStyles.title}>{title}</BN2>
       </View>
 
       {rightIcon ? (
         rightIcon
       ) : (
-        <MaterialIcons name="chevron-right" size={24} color={Colors.neutral_400} />
+        <MaterialIcons name="chevron-right" size={verticalScale(24)} color={Colors.neutral_400} />
       )}
     </TouchableOpacity>
   );

--- a/app/(settings)/components/SettingsListItem.tsx
+++ b/app/(settings)/components/SettingsListItem.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { TouchableOpacity, View } from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { Colors } from "@/constants/Colors";
+import { BN1 } from "@/components/ThemedText";
+import settingsListItemStyles from "@/app/(settings)/components/SettingsListItem.styles";
+import { useRouter } from "expo-router";
+
+interface SettingsListItemProps {
+  title: string;
+  route?: string;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+}
+
+const SettingsListItem: React.FC<SettingsListItemProps> = ({
+  title,
+  route,
+  leftIcon,
+  rightIcon,
+}) => {
+  const router = useRouter();
+
+  const handlePress = (route: string) => {
+    router.push(route as any);
+  };
+
+  return (
+    <TouchableOpacity
+      style={settingsListItemStyles.settingItem}
+      onPress={() => handlePress(route ?? "/(settings)")}
+    >
+      <View style={settingsListItemStyles.iconContainer}>{leftIcon}</View>
+
+      <View style={settingsListItemStyles.textContainer}>
+        <BN1 style={settingsListItemStyles.title}>{title}</BN1>
+      </View>
+
+      {rightIcon ? (
+        rightIcon
+      ) : (
+        <MaterialIcons name="chevron-right" size={24} color={Colors.neutral_400} />
+      )}
+    </TouchableOpacity>
+  );
+};
+
+export default SettingsListItem;

--- a/app/(settings)/index.styles.ts
+++ b/app/(settings)/index.styles.ts
@@ -1,0 +1,13 @@
+import { StyleSheet } from "react-native";
+
+const settingsStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+  },
+});
+
+export default settingsStyles;

--- a/app/(settings)/index.styles.ts
+++ b/app/(settings)/index.styles.ts
@@ -1,12 +1,53 @@
 import { StyleSheet } from "react-native";
+import { horizontalScale, paddingScale, verticalScale } from "@/libs/utils/scaling";
+import { commonStyles } from "@/components/common.styles";
+import { Colors } from "@/constants/Colors";
 
 const settingsStyles = StyleSheet.create({
   container: {
     flex: 1,
+    ...paddingScale(16),
+    gap: verticalScale(16),
   },
-  content: {
-    flex: 1,
-    padding: 20,
+  goalContentContainer: {
+    ...paddingScale(8, 0),
+    gap: verticalScale(12),
+    borderBottomWidth: horizontalScale(1),
+    borderBottomColor: Colors.neutral_100,
+  },
+  goalWrapper: {
+    ...commonStyles.flexRow,
+    alignItems: "center",
+    gap: horizontalScale(16),
+    ...paddingScale(0, 12),
+  },
+  goalText: {
+    fontWeight: "500",
+  },
+  badgeWrapper: {
+    justifyContent: "center",
+    alignItems: "center",
+    borderRadius: verticalScale(4),
+    ...paddingScale(4),
+  },
+  alarmContainer: {
+    ...paddingScale(12),
+    gap: verticalScale(8),
+  },
+  alarmWrapper: {
+    ...commonStyles.flexRow,
+    justifyContent: "space-between",
+  },
+  alarmTitle: {
+    fontWeight: "500",
+  },
+  versionInfoContainer: {
+    ...paddingScale(12, 8, 12, 12),
+    ...commonStyles.flexRow,
+    justifyContent: "space-between",
+  },
+  versionInfoWrapper: {
+    fontWeight: "500",
   },
 });
 

--- a/app/(settings)/index.tsx
+++ b/app/(settings)/index.tsx
@@ -1,0 +1,30 @@
+import { ThemedView } from "@/components/ThemedView";
+import React from "react";
+import { View } from "react-native";
+import SettingsListItem from "@/app/(settings)/components/SettingsListItem";
+import settingsStyles from "@/app/(settings)/index.styles";
+
+const SettingsScreen = () => {
+  const settingsItems = [
+    {
+      title: "개인 설정",
+      route: "/(settings)/personal",
+    },
+    {
+      title: "로그인 정보",
+      route: "/(settings)/login-info",
+    },
+  ];
+
+  return (
+    <ThemedView style={settingsStyles.container}>
+      <View style={settingsStyles.content}>
+        {settingsItems.map((item, index) => (
+          <SettingsListItem key={`settings_${index}`} title={item.title} />
+        ))}
+      </View>
+    </ThemedView>
+  );
+};
+
+export default SettingsScreen;

--- a/app/(settings)/index.tsx
+++ b/app/(settings)/index.tsx
@@ -1,29 +1,75 @@
 import { ThemedView } from "@/components/ThemedView";
-import React from "react";
-import { View } from "react-native";
+import React, { useState } from "react";
 import SettingsListItem from "@/app/(settings)/components/SettingsListItem";
 import settingsStyles from "@/app/(settings)/index.styles";
+import { View } from "react-native";
+import { Colors } from "@/constants/Colors";
+import { horizontalScale } from "@/libs/utils/scaling";
+import { BN2, L2, LN1 } from "@/components/ThemedText";
+import { CustomToggle } from "@/components/CustomToggle";
 
 const SettingsScreen = () => {
-  const settingsItems = [
-    {
-      title: "개인 설정",
-      route: "/(settings)/personal",
-    },
-    {
-      title: "로그인 정보",
-      route: "/(settings)/login-info",
-    },
-  ];
+  const [isToggled, setIsToggled] = useState(false);
 
   return (
     <ThemedView style={settingsStyles.container}>
-      <View style={settingsStyles.content}>
-        {settingsItems.map((item, index) => (
-          <SettingsListItem key={`settings_${index}`} title={item.title} />
-        ))}
+      <View style={settingsStyles.goalContentContainer}>
+        <View style={settingsStyles.goalWrapper}>
+          <LN1 style={settingsStyles.goalText} lightColor={Colors.neutral_600}>
+            목표 수분 섭취량
+          </LN1>
+          <Badge content={"2500ml"} badgeColor={Colors.primary_010} maxWidth={60} />
+        </View>
+
+        <SettingsListItem title={"다시 측정하기"} />
+        <SettingsListItem title={"직접 설정"} />
+      </View>
+      <View>
+        <View style={settingsStyles.alarmContainer}>
+          <View style={settingsStyles.alarmWrapper}>
+            <BN2 style={settingsStyles.alarmTitle} lightColor={Colors.neutral_800}>
+              수분 섭취 알림
+            </BN2>
+            <CustomToggle value={isToggled} onValueChange={() => setIsToggled(!isToggled)} />
+          </View>
+          <L2 lightColor={Colors.neutral_600}>수분 섭취가 필요할 때 알려드려요.</L2>
+        </View>
+
+        <SettingsListItem title={"로그인 정보"} />
+
+        <View style={settingsStyles.versionInfoContainer}>
+          <BN2 style={settingsStyles.versionInfoWrapper} lightColor={Colors.neutral_800}>
+            앱 버전
+          </BN2>
+          <LN1 lightColor={Colors.neutral_400}>1.0.0</LN1>
+        </View>
       </View>
     </ThemedView>
+  );
+};
+
+// TODO: Badge 공용 컴포넌트로 대체
+const Badge = ({
+  content,
+  badgeColor,
+  maxWidth,
+}: {
+  content: string;
+  badgeColor: string;
+  maxWidth?: number;
+}) => {
+  return (
+    <View
+      style={{
+        ...settingsStyles.badgeWrapper,
+        maxWidth: horizontalScale(maxWidth ?? 40),
+        backgroundColor: badgeColor,
+      }}
+    >
+      <L2 lightColor={Colors.primary_500} style={{ fontWeight: "500" }}>
+        {content}
+      </L2>
+    </View>
   );
 };
 

--- a/app/(settings)/index.tsx
+++ b/app/(settings)/index.tsx
@@ -35,7 +35,7 @@ const SettingsScreen = () => {
           <L2 lightColor={Colors.neutral_600}>수분 섭취가 필요할 때 알려드려요.</L2>
         </View>
 
-        <SettingsListItem title={"로그인 정보"} />
+        <SettingsListItem title={"로그인 정보"} route={"/(settings)/login-info"} />
 
         <View style={settingsStyles.versionInfoContainer}>
           <BN2 style={settingsStyles.versionInfoWrapper} lightColor={Colors.neutral_800}>

--- a/app/(settings)/login-info.styles.ts
+++ b/app/(settings)/login-info.styles.ts
@@ -1,0 +1,24 @@
+import { StyleSheet } from "react-native";
+import { paddingScale } from "@/libs/utils/scaling";
+import { commonStyles } from "@/components/common.styles";
+
+const loginInfoStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+    ...paddingScale(16),
+  },
+  listItemWrapper: {
+    ...paddingScale(12, 8, 12, 12),
+    ...commonStyles.flexRow,
+    justifyContent: "space-between",
+  },
+  listItemLabel: {
+    fontWeight: "500",
+  },
+  unRegister: {
+    fontWeight: "500",
+    textDecorationLine: "underline",
+  },
+});
+
+export default loginInfoStyles;

--- a/app/(settings)/login-info.tsx
+++ b/app/(settings)/login-info.tsx
@@ -1,26 +1,28 @@
-import { BN1, H1 } from "@/components/ThemedText";
+import { BN1, BN2, LR1 } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 import React from "react";
-import { ScrollView, View } from "react-native";
+import { TouchableOpacity, View } from "react-native";
+import SettingsListItem from "@/app/(settings)/components/SettingsListItem";
+import loginInfoStyles from "@/app/(settings)/login-info.styles";
+import { Colors } from "@/constants/Colors";
 
 export default function LoginInfoScreen() {
   return (
-    <ThemedView style={{ flex: 1 }}>
-      <ScrollView style={{ flex: 1, padding: 20 }}>
-        <H1 style={{ marginBottom: 20 }}>로그인 정보</H1>
+    <ThemedView style={loginInfoStyles.container}>
+      <View style={loginInfoStyles.listItemWrapper}>
+        <BN1 style={loginInfoStyles.listItemLabel}>소셜 정보</BN1>
+        <LR1 lightColor={Colors.neutral_400}>asdfasdf@kakaotalk.com</LR1>
+      </View>
 
-        <View style={{ marginBottom: 16 }}>
-          <BN1>연결된 계정</BN1>
-        </View>
+      <SettingsListItem title={"로그아웃"} />
 
-        <View style={{ marginBottom: 16 }}>
-          <BN1>비밀번호 변경</BN1>
-        </View>
-
-        <View style={{ marginBottom: 16 }}>
-          <BN1>계정 관리</BN1>
-        </View>
-      </ScrollView>
+      <View style={loginInfoStyles.listItemWrapper}>
+        <TouchableOpacity onPress={() => console.log("unregister")}>
+          <BN2 style={loginInfoStyles.unRegister} lightColor={Colors.neutral_400}>
+            회원탈퇴
+          </BN2>
+        </TouchableOpacity>
+      </View>
     </ThemedView>
   );
 }

--- a/app/(settings)/login-info.tsx
+++ b/app/(settings)/login-info.tsx
@@ -1,0 +1,26 @@
+import { BN1, H1 } from "@/components/ThemedText";
+import { ThemedView } from "@/components/ThemedView";
+import React from "react";
+import { ScrollView, View } from "react-native";
+
+export default function LoginInfoScreen() {
+  return (
+    <ThemedView style={{ flex: 1 }}>
+      <ScrollView style={{ flex: 1, padding: 20 }}>
+        <H1 style={{ marginBottom: 20 }}>로그인 정보</H1>
+
+        <View style={{ marginBottom: 16 }}>
+          <BN1>연결된 계정</BN1>
+        </View>
+
+        <View style={{ marginBottom: 16 }}>
+          <BN1>비밀번호 변경</BN1>
+        </View>
+
+        <View style={{ marginBottom: 16 }}>
+          <BN1>계정 관리</BN1>
+        </View>
+      </ScrollView>
+    </ThemedView>
+  );
+}

--- a/app/(settings)/personal.tsx
+++ b/app/(settings)/personal.tsx
@@ -1,0 +1,26 @@
+import { BN1, H1 } from "@/components/ThemedText";
+import { ThemedView } from "@/components/ThemedView";
+import React from "react";
+import { ScrollView, View } from "react-native";
+
+export default function PersonalScreen() {
+  return (
+    <ThemedView style={{ flex: 1 }}>
+      <ScrollView style={{ flex: 1, padding: 20 }}>
+        <H1 style={{ marginBottom: 20 }}>개인 설정</H1>
+
+        <View style={{ marginBottom: 16 }}>
+          <BN1>프로필 정보</BN1>
+        </View>
+
+        <View style={{ marginBottom: 16 }}>
+          <BN1>알림 설정</BN1>
+        </View>
+
+        <View style={{ marginBottom: 16 }}>
+          <BN1>개인정보 설정</BN1>
+        </View>
+      </ScrollView>
+    </ThemedView>
+  );
+}

--- a/app/(tabs)/components/AddNewRecord.styles.ts
+++ b/app/(tabs)/components/AddNewRecord.styles.ts
@@ -1,24 +1,10 @@
 import { StyleSheet } from "react-native";
-import { horizontalScale, marginScale, verticalScale } from "@/libs/utils/scaling";
-import { commonStyles } from "@/components/common.styles";
+import { verticalScale } from "@/libs/utils/scaling";
 
 const addNewRecordStyles = StyleSheet.create({
   bottomSheetContainer: {
     flex: 1,
     gap: verticalScale(24),
-  },
-  header: {
-    ...commonStyles.flexRow,
-    justifyContent: "space-between",
-  },
-  inputMeasurement: {
-    ...commonStyles.flexRow,
-    gap: horizontalScale(12),
-    alignItems: "center",
-  },
-  sliderWrapper: {
-    flex: 1,
-    ...marginScale(20, 0),
   },
 });
 

--- a/app/(tabs)/components/AddNewRecord.tsx
+++ b/app/(tabs)/components/AddNewRecord.tsx
@@ -16,7 +16,7 @@ interface addNewRecordProps {
 
 const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
   const [currentTab, setCurrentTab] = useState<TabType>("물");
-  const [currentVal, setCurrentVal] = useState(500);
+  const [currentVal, setCurrentVal] = useState(50);
   const { currentIndex } = useBeverageStore();
 
   const addAmount = () => {

--- a/app/(tabs)/components/AddNewRecord.tsx
+++ b/app/(tabs)/components/AddNewRecord.tsx
@@ -4,12 +4,10 @@ import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet"
 import { CustomTab, TabType } from "@/components/CustomTab";
 import React, { useState } from "react";
 import { View } from "react-native";
-import CustomSlider from "@/components/CustomSlider/CustomSlider";
-import { BN1, LN1 } from "@/components/ThemedText";
-import { Colors } from "@/constants/Colors";
 import CustomButton from "@/components/CustomButton/CustomButton";
 import { useBeverageStore } from "@/stores/beverageStore";
 import { dummyBeverages } from "@/app/(tabs)/constants/beverageDataSet";
+import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
 
 interface addNewRecordProps {
   isOpen: boolean;
@@ -38,27 +36,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
           />
         </View>
 
-        <View style={addNewRecordStyles.header}>
-          <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
-            마신 양을 얼마나 추가할까요?
-          </BN1>
-
-          <View style={addNewRecordStyles.inputMeasurement}>
-            <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
-              {currentVal}
-            </BN1>
-            <LN1 lightColor={Colors.neutral_400}>ml</LN1>
-          </View>
-        </View>
-
-        <CustomSlider
-          sliderVal={currentVal}
-          onValueChange={(val) => setCurrentVal(val[0])}
-          step={50}
-          animationType={"spring"}
-          maximumValue={1000}
-          minimumValue={0}
-        />
+        <RecordAmountSection currentVal={currentVal} setCurrentVal={setCurrentVal} />
 
         <CustomButton title={"확인"} textStyle={{ fontWeight: "bold" }} onPress={addAmount} />
       </View>

--- a/app/(tabs)/components/AddYourselfSlide.tsx
+++ b/app/(tabs)/components/AddYourselfSlide.tsx
@@ -45,6 +45,7 @@ const AddYourselfSlide: React.FC<AddYourselfSlideProps> = ({ style, onPress }) =
   );
 };
 
+// TODO: Badge 공용 컴포넌트로 대체
 const Badge = ({
   content,
   badgeColor,

--- a/app/(tabs)/index.styles.ts
+++ b/app/(tabs)/index.styles.ts
@@ -4,7 +4,6 @@ import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
 
 export const tabsStyles = StyleSheet.create({
   mainContainer: {
-    flex: 1,
     ...commonStyles.pageContainer,
     ...commonStyles.transparentView,
   },

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -56,7 +56,11 @@ export default function HomeScreen() {
             onPress={() => router.push("/record-history")}
           />
 
-          <CustomInput label={"Input Title"} errorText={"*10자 이내로 작성해주세요."} />
+          <CustomInput
+            label={"Input Title"}
+            errorText={"*10자 이내로 작성해주세요."}
+            detailText={"*detail"}
+          />
         </ScrollView>
       </SafeAreaView>
       <AddNewRecord isOpen={isAddNewRecordOpen} onClose={() => setIsAddNewRecordOpen(false)} />

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,6 +8,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import renderItem from "@/app/(tabs)/utils/renderItem";
 import beverageDataSet from "@/app/(tabs)/constants/beverageDataSet";
 import AddNewRecord from "@/app/(tabs)/components/AddNewRecord";
+import CustomButton from "@/components/CustomButton/CustomButton";
+import { useRouter } from "expo-router";
 
 const { width: screenWidth } = Dimensions.get("window");
 const DESIGN_WIDTH = 375;
@@ -16,6 +18,7 @@ const bgHeight = (screenWidth / DESIGN_WIDTH) * DESIGN_HEIGHT;
 
 export default function HomeScreen() {
   const [isAddNewRecordOpen, setIsAddNewRecordOpen] = useState(false);
+  const router = useRouter();
 
   const handleBottomSheetOpen = () => {
     setIsAddNewRecordOpen(!isAddNewRecordOpen);
@@ -45,6 +48,12 @@ export default function HomeScreen() {
               })}
             />
           </View>
+
+          <CustomButton
+            title={"섭취 기록으로(임시)"}
+            variant={"secondary"}
+            onPress={() => router.push("/record-history")}
+          />
         </ScrollView>
       </SafeAreaView>
       <AddNewRecord isOpen={isAddNewRecordOpen} onClose={() => setIsAddNewRecordOpen(false)} />

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,6 +10,7 @@ import beverageDataSet from "@/app/(tabs)/constants/beverageDataSet";
 import AddNewRecord from "@/app/(tabs)/components/AddNewRecord";
 import CustomButton from "@/components/CustomButton/CustomButton";
 import { useRouter } from "expo-router";
+import CustomInput from "@/components/CustomInput/CustomInput";
 
 const { width: screenWidth } = Dimensions.get("window");
 const DESIGN_WIDTH = 375;
@@ -54,6 +55,8 @@ export default function HomeScreen() {
             variant={"secondary"}
             onPress={() => router.push("/record-history")}
           />
+
+          <CustomInput label={"Input Title"} errorText={"*10자 이내로 작성해주세요."} />
         </ScrollView>
       </SafeAreaView>
       <AddNewRecord isOpen={isAddNewRecordOpen} onClose={() => setIsAddNewRecordOpen(false)} />

--- a/app/onboard-survey/_layout.tsx
+++ b/app/onboard-survey/_layout.tsx
@@ -1,10 +1,7 @@
-import { ThemedView } from "@/components/ThemedView";
-import { Colors } from "@/constants/Colors";
 import { useOnboardStepStore } from "@/stores/onboardStepStore";
-import { MaterialIcons } from "@expo/vector-icons";
 import { Stack, useRouter } from "expo-router";
 import React from "react";
-import { TouchableOpacity } from "react-native";
+import CommonHeader from "@/components/CommonHeader/CommonHeader";
 
 export default function OnboardSurveyLayout() {
   const { currentStep, prevStep } = useOnboardStepStore();
@@ -21,17 +18,8 @@ export default function OnboardSurveyLayout() {
   return (
     <Stack
       screenOptions={{
+        header: () => <CommonHeader onPressIcon={handleBack} isEmpty={currentStep === 1} />,
         headerTitle: "",
-        headerLeft: () => (
-          <TouchableOpacity onPress={handleBack}>
-            <ThemedView>
-              {/*  TODO: 최초 단계 시 스플래시 화면으로 이동 로직 추가 및 아이콘 되돌리기 */}
-              {currentStep > 1 && (
-                <MaterialIcons name={"arrow-back"} size={24} color={Colors.neutral_400} />
-              )}
-            </ThemedView>
-          </TouchableOpacity>
-        ),
       }}
     />
   );

--- a/app/onboard-survey/_layout.tsx
+++ b/app/onboard-survey/_layout.tsx
@@ -19,7 +19,6 @@ export default function OnboardSurveyLayout() {
     <Stack
       screenOptions={{
         header: () => <CommonHeader onPressIcon={handleBack} isEmpty={currentStep === 1} />,
-        headerTitle: "",
       }}
     />
   );

--- a/app/onboard-survey/index.tsx
+++ b/app/onboard-survey/index.tsx
@@ -11,7 +11,7 @@ import BirthYearStep from "@/app/onboard-survey/steps/BirthYearStep";
 import WeightStep from "@/app/onboard-survey/steps/WeightStep";
 import ActivityStep from "@/app/onboard-survey/steps/ActivityStep";
 import indexStyles from "@/app/onboard-survey/index.styles";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { View } from "react-native";
 
 const categories = ["성별", "출생연도", "체중", "하루 평균 활동량"];
 
@@ -67,7 +67,7 @@ const OnboardSurvey = () => {
     (currentStep === 1 && !isGenderSelected) || (currentStep === 4 && !isActivitySelected);
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <View style={{ flex: 1 }}>
       <FormProvider {...methods}>
         <ThemedView style={indexStyles.SurveyPageContainer}>
           <SurveyProgressBar currentStep={currentStep} totalSteps={stepComponents.length} />
@@ -86,7 +86,7 @@ const OnboardSurvey = () => {
           </ThemedView>
         </ThemedView>
       </FormProvider>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/app/record-history/_layout.tsx
+++ b/app/record-history/_layout.tsx
@@ -1,0 +1,14 @@
+import { Stack } from "expo-router";
+import React from "react";
+import CommonHeader from "@/components/CommonHeader/CommonHeader";
+
+export default function RecordHistoryLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        header: () => <CommonHeader />,
+        headerTitle: "",
+      }}
+    />
+  );
+}

--- a/app/record-history/_layout.tsx
+++ b/app/record-history/_layout.tsx
@@ -6,8 +6,7 @@ export default function RecordHistoryLayout() {
   return (
     <Stack
       screenOptions={{
-        header: () => <CommonHeader />,
-        headerTitle: "",
+        header: () => <CommonHeader title={"지난 섭취 기록"} />,
       }}
     />
   );

--- a/app/record-history/components/AddPastRecord.styles.ts
+++ b/app/record-history/components/AddPastRecord.styles.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from "react-native";
+import { commonStyles } from "@/components/common.styles";
+import { horizontalScale } from "@/libs/utils/scaling";
+
+export const addPastRecordStyles = StyleSheet.create({
+  timeModeHeader: {
+    ...commonStyles.flexRow,
+    gap: horizontalScale(16),
+    alignItems: "center",
+  },
+});

--- a/app/record-history/components/AddPastRecord.styles.ts
+++ b/app/record-history/components/AddPastRecord.styles.ts
@@ -1,8 +1,11 @@
 import { StyleSheet } from "react-native";
 import { commonStyles } from "@/components/common.styles";
-import { horizontalScale } from "@/libs/utils/scaling";
+import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
 
 const addPastRecordStyles = StyleSheet.create({
+  bottomSheetContainer: {
+    gap: verticalScale(24),
+  },
   timeModeHeader: {
     ...commonStyles.flexRow,
     gap: horizontalScale(16),

--- a/app/record-history/components/AddPastRecord.styles.ts
+++ b/app/record-history/components/AddPastRecord.styles.ts
@@ -2,10 +2,12 @@ import { StyleSheet } from "react-native";
 import { commonStyles } from "@/components/common.styles";
 import { horizontalScale } from "@/libs/utils/scaling";
 
-export const addPastRecordStyles = StyleSheet.create({
+const addPastRecordStyles = StyleSheet.create({
   timeModeHeader: {
     ...commonStyles.flexRow,
     gap: horizontalScale(16),
     alignItems: "center",
   },
 });
+
+export default addPastRecordStyles;

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -1,0 +1,95 @@
+import addNewRecordStyles from "@/app/(tabs)/components/AddNewRecord.styles";
+import { commonStyles } from "@/components/common.styles";
+import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
+import { CustomTab, TabType } from "@/components/CustomTab";
+import React, { useState } from "react";
+import { TouchableOpacity, View } from "react-native";
+import CustomSlider from "@/components/CustomSlider/CustomSlider";
+import { BN1, LN1 } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import CustomButton from "@/components/CustomButton/CustomButton";
+import { useBeverageStore } from "@/stores/beverageStore";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { addPastRecordStyles } from "@/app/record-history/components/AddPastRecord.styles";
+
+interface addNewRecordProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
+  const [currentTab, setCurrentTab] = useState<TabType>("물");
+  const [currentVal, setCurrentVal] = useState(500);
+  const [timeVal, setTimeVal] = useState(0);
+  const [addTimeMode, setAddTimeMode] = useState(false);
+  const { currentIndex } = useBeverageStore();
+
+  const setTimeMode = () => {
+    // TODO: 음료량 기록 API 연동 시 삭제 + 연동하기
+    setAddTimeMode(true);
+  };
+
+  const addTime = () => {
+    onClose();
+  };
+
+  const goBack = () => {
+    setAddTimeMode(false);
+  };
+
+  return (
+    <CustomBottomSheet isOpen={isOpen} onClose={onClose}>
+      {!addTimeMode ? (
+        <View style={addNewRecordStyles.bottomSheetContainer}>
+          <View style={commonStyles.flexRow}>
+            <CustomTab
+              selectedTab={currentTab}
+              onSelectTab={(tab) => setCurrentTab(tab)}
+              visibleTabs={["물", "커피", "녹차"]}
+            />
+          </View>
+
+          <View style={addNewRecordStyles.header}>
+            <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
+              마신 양을 얼마나 추가할까요?
+            </BN1>
+
+            <View style={addNewRecordStyles.inputMeasurement}>
+              <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
+                {currentVal}
+              </BN1>
+              <LN1 lightColor={Colors.neutral_400}>ml</LN1>
+            </View>
+          </View>
+
+          <CustomSlider
+            sliderVal={currentVal}
+            onValueChange={(val) => setCurrentVal(val[0])}
+            step={50}
+            animationType={"spring"}
+            maximumValue={1000}
+            minimumValue={0}
+          />
+
+          <CustomButton
+            title={"시간 추가"}
+            textStyle={{ fontWeight: "bold" }}
+            onPress={setTimeMode}
+          />
+        </View>
+      ) : (
+        <View style={addNewRecordStyles.bottomSheetContainer}>
+          <View style={addPastRecordStyles.timeModeHeader}>
+            <TouchableOpacity onPress={goBack}>
+              <MaterialIcons name={"arrow-back"} size={16} color={Colors.neutral_400} />
+            </TouchableOpacity>
+            <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
+          </View>
+          <CustomButton title={"완료"} textStyle={{ fontWeight: "bold" }} onPress={addTime} />
+        </View>
+      )}
+    </CustomBottomSheet>
+  );
+};
+
+export default AddNewRecord;

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -1,4 +1,3 @@
-import addNewRecordStyles from "@/app/(tabs)/components/AddNewRecord.styles";
 import { commonStyles } from "@/components/common.styles";
 import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
 import CustomButton from "@/components/CustomButton/CustomButton";
@@ -48,7 +47,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
   return (
     <CustomBottomSheet isOpen={isOpen} onClose={handleClose}>
       {!addTimeMode ? (
-        <View style={addNewRecordStyles.bottomSheetContainer}>
+        <View style={addPastRecordStyles.bottomSheetContainer}>
           <View style={commonStyles.flexRow}>
             <CustomTab
               selectedTab={currentTab}
@@ -66,7 +65,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
           />
         </View>
       ) : (
-        <View style={addNewRecordStyles.bottomSheetContainer}>
+        <View style={addPastRecordStyles.bottomSheetContainer}>
           <View style={addPastRecordStyles.timeModeHeader}>
             <TouchableOpacity onPress={goBack}>
               <MaterialIcons

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -1,5 +1,4 @@
 import addNewRecordStyles from "@/app/(tabs)/components/AddNewRecord.styles";
-import { addPastRecordStyles } from "@/app/record-history/components/AddPastRecord.styles";
 import { commonStyles } from "@/components/common.styles";
 import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
 import CustomButton from "@/components/CustomButton/CustomButton";
@@ -11,6 +10,7 @@ import React, { useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
 import RecordTimePickerSection from "@/components/CustomBottomSheet/RecordTimePickerSection";
+import addPastRecordStyles from "@/app/record-history/components/AddPastRecord.styles";
 
 interface addNewRecordProps {
   isOpen: boolean;

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -1,86 +1,58 @@
-import { commonStyles } from "@/components/common.styles";
 import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
-import CustomButton from "@/components/CustomButton/CustomButton";
-import { CustomTab, TabType } from "@/components/CustomTab";
-import { BN1 } from "@/components/ThemedText";
-import { Colors } from "@/constants/Colors";
-import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import React, { useState } from "react";
-import { TouchableOpacity, View } from "react-native";
-import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
-import RecordTimePickerSection from "@/components/CustomBottomSheet/RecordTimePickerSection";
-import addPastRecordStyles from "@/app/record-history/components/AddPastRecord.styles";
-import { verticalScale } from "@/libs/utils/scaling";
+import React from "react";
+import { useAddPastRecord } from "../hooks/useAddPastRecord";
+import AmountStep from "./AmountStep";
+import TimeStep from "./TimeStep";
 
-interface addNewRecordProps {
+interface AddNewRecordProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
-  const [currentTab, setCurrentTab] = useState<TabType>("물");
-  const [currentVal, setCurrentVal] = useState(500);
-  const [addTimeMode, setAddTimeMode] = useState(false);
-  const [selectedDate, setSelectedDate] = useState(new Date());
+const AddNewRecord: React.FC<AddNewRecordProps> = ({ isOpen, onClose }) => {
+  const {
+    currentTab,
+    setCurrentTab,
+    addTimeMode,
+    currentVal,
+    selectedDate,
+    setCurrentVal,
+    setSelectedDate,
+    handleSubmit,
+    onSubmit,
+    setTimeMode,
+    goBack,
+    handleClose,
+  } = useAddPastRecord();
 
-  const setTimeMode = () => {
-    // TODO: 음료량 기록 API 연동 시 삭제 + 연동하기
-    setAddTimeMode(true);
+  const handleCloseModal = () => {
+    handleClose(onClose);
   };
 
-  const addTime = () => {
-    // TODO: 완료 시 submit API 연동
-    onClose();
-  };
-
-  const goBack = () => {
-    setAddTimeMode(false);
-  };
-
-  const handleClose = () => {
-    // 기존 값은 유지, setTimeMode 만 false 처리
-    // TODO: 이 부분에 대한 로직 논의
-    setAddTimeMode(false);
-    onClose();
+  const handleSubmitForm = () => {
+    handleSubmit((data: any) => {
+      onSubmit(data);
+      onClose();
+    })();
   };
 
   return (
-    <CustomBottomSheet isOpen={isOpen} onClose={handleClose}>
+    <CustomBottomSheet isOpen={isOpen} onClose={handleCloseModal}>
       {!addTimeMode ? (
-        <View style={addPastRecordStyles.bottomSheetContainer}>
-          <View style={commonStyles.flexRow}>
-            <CustomTab
-              selectedTab={currentTab}
-              onSelectTab={(tab) => setCurrentTab(tab)}
-              visibleTabs={["물", "커피", "녹차"]}
-            />
-          </View>
-
-          <RecordAmountSection currentVal={currentVal} setCurrentVal={setCurrentVal} />
-
-          <CustomButton
-            title={"시간 추가"}
-            textStyle={{ fontWeight: "bold" }}
-            onPress={setTimeMode}
-          />
-        </View>
+        <AmountStep
+          currentTab={currentTab}
+          onSelectTab={setCurrentTab}
+          currentVal={currentVal}
+          setCurrentVal={setCurrentVal}
+          onNext={setTimeMode}
+        />
       ) : (
-        <View style={addPastRecordStyles.bottomSheetContainer}>
-          <View style={addPastRecordStyles.timeModeHeader}>
-            <TouchableOpacity onPress={goBack}>
-              <MaterialIcons
-                name={"arrow-back"}
-                size={verticalScale(24)}
-                color={Colors.neutral_400}
-              />
-            </TouchableOpacity>
-            <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
-          </View>
-
-          <RecordTimePickerSection value={selectedDate} onChange={setSelectedDate} />
-
-          <CustomButton title={"완료"} textStyle={{ fontWeight: "bold" }} onPress={addTime} />
-        </View>
+        <TimeStep
+          selectedDate={selectedDate}
+          setSelectedDate={setSelectedDate}
+          onBack={goBack}
+          onSubmit={handleSubmitForm}
+        />
       )}
     </CustomBottomSheet>
   );

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -29,6 +29,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
   };
 
   const addTime = () => {
+    // TODO: 완료 시 submit API 연동
     onClose();
   };
 
@@ -36,8 +37,15 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
     setAddTimeMode(false);
   };
 
+  const handleClose = () => {
+    // 기존 값은 유지, setTimeMode 만 false 처리
+    // TODO: 이 부분에 대한 로직 논의
+    setAddTimeMode(false);
+    onClose();
+  };
+
   return (
-    <CustomBottomSheet isOpen={isOpen} onClose={onClose}>
+    <CustomBottomSheet isOpen={isOpen} onClose={handleClose}>
       {!addTimeMode ? (
         <View style={addNewRecordStyles.bottomSheetContainer}>
           <View style={commonStyles.flexRow}>

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -3,14 +3,14 @@ import { addPastRecordStyles } from "@/app/record-history/components/AddPastReco
 import { commonStyles } from "@/components/common.styles";
 import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
 import CustomButton from "@/components/CustomButton/CustomButton";
-import CustomSlider from "@/components/CustomSlider/CustomSlider";
 import { CustomTab, TabType } from "@/components/CustomTab";
-import { BN1, LN1 } from "@/components/ThemedText";
+import { BN1 } from "@/components/ThemedText";
 import { Colors } from "@/constants/Colors";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import React, { useState } from "react";
 import { TouchableOpacity, View } from "react-native";
-import WheelPicker from "react-native-wheel-picker-expo";
+import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
+import RecordTimePickerSection from "@/components/CustomBottomSheet/RecordTimePickerSection";
 
 interface addNewRecordProps {
   isOpen: boolean;
@@ -21,31 +21,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
   const [currentTab, setCurrentTab] = useState<TabType>("물");
   const [currentVal, setCurrentVal] = useState(500);
   const [addTimeMode, setAddTimeMode] = useState(false);
-
-  const ampmOptions = [
-    { label: "오전", value: "AM" },
-    { label: "오후", value: "PM" },
-  ];
-  const hourOptions = Array.from({ length: 12 }, (_, i) => ({
-    label: String(i + 1),
-    value: String(i + 1),
-  }));
-  const minuteOptions = Array.from({ length: 60 }, (_, i) => ({
-    label: i.toString().padStart(2, "0"),
-    value: String(i),
-  }));
-
-  // 현재 시간 계산
-  const now = new Date();
-  const nowHour24 = now.getHours();
-  const nowMinute = now.getMinutes();
-  const initialAmpm = nowHour24 < 12 ? "AM" : "PM";
-  const initialHour = (nowHour24 % 12 || 12).toString();
-  const initialMinute = nowMinute.toString().padStart(2, "0");
-
-  const [ampm, setAmpm] = useState(initialAmpm);
-  const [hour, setHour] = useState(initialHour);
-  const [minute, setMinute] = useState(initialMinute);
+  const [selectedDate, setSelectedDate] = useState(new Date());
 
   const setTimeMode = () => {
     // TODO: 음료량 기록 API 연동 시 삭제 + 연동하기
@@ -72,27 +48,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
             />
           </View>
 
-          <View style={addNewRecordStyles.header}>
-            <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
-              마신 양을 얼마나 추가할까요?
-            </BN1>
-
-            <View style={addNewRecordStyles.inputMeasurement}>
-              <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
-                {currentVal}
-              </BN1>
-              <LN1 lightColor={Colors.neutral_400}>ml</LN1>
-            </View>
-          </View>
-
-          <CustomSlider
-            sliderVal={currentVal}
-            onValueChange={(val) => setCurrentVal(val[0])}
-            step={50}
-            animationType={"spring"}
-            maximumValue={1000}
-            minimumValue={0}
-          />
+          <RecordAmountSection currentVal={currentVal} setCurrentVal={setCurrentVal} />
 
           <CustomButton
             title={"시간 추가"}
@@ -109,38 +65,7 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
             <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
           </View>
 
-          <View
-            style={{
-              flexDirection: "row",
-              justifyContent: "center",
-              alignItems: "center",
-            }}
-          >
-            <WheelPicker
-              height={172}
-              width={80}
-              items={ampmOptions}
-              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
-              initialSelectedIndex={ampm === "AM" ? 0 : 1}
-              onChange={({ item }) => setAmpm(item.value)}
-            />
-            <WheelPicker
-              height={172}
-              width={80}
-              items={hourOptions}
-              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
-              initialSelectedIndex={Number(hour) - 1}
-              onChange={({ item }) => setHour(item.value)}
-            />
-            <WheelPicker
-              height={172}
-              width={80}
-              items={minuteOptions}
-              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
-              initialSelectedIndex={Number(minute)}
-              onChange={({ item }) => setMinute(item.value)}
-            />
-          </View>
+          <RecordTimePickerSection value={selectedDate} onChange={setSelectedDate} />
 
           <CustomButton title={"완료"} textStyle={{ fontWeight: "bold" }} onPress={addTime} />
         </View>

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -1,16 +1,16 @@
 import addNewRecordStyles from "@/app/(tabs)/components/AddNewRecord.styles";
+import { addPastRecordStyles } from "@/app/record-history/components/AddPastRecord.styles";
 import { commonStyles } from "@/components/common.styles";
 import CustomBottomSheet from "@/components/CustomBottomSheet/CustomBottomSheet";
-import { CustomTab, TabType } from "@/components/CustomTab";
-import React, { useState } from "react";
-import { TouchableOpacity, View } from "react-native";
+import CustomButton from "@/components/CustomButton/CustomButton";
 import CustomSlider from "@/components/CustomSlider/CustomSlider";
+import { CustomTab, TabType } from "@/components/CustomTab";
 import { BN1, LN1 } from "@/components/ThemedText";
 import { Colors } from "@/constants/Colors";
-import CustomButton from "@/components/CustomButton/CustomButton";
-import { useBeverageStore } from "@/stores/beverageStore";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import { addPastRecordStyles } from "@/app/record-history/components/AddPastRecord.styles";
+import React, { useState } from "react";
+import { TouchableOpacity, View } from "react-native";
+import WheelPicker from "react-native-wheel-picker-expo";
 
 interface addNewRecordProps {
   isOpen: boolean;
@@ -20,9 +20,32 @@ interface addNewRecordProps {
 const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
   const [currentTab, setCurrentTab] = useState<TabType>("물");
   const [currentVal, setCurrentVal] = useState(500);
-  const [timeVal, setTimeVal] = useState(0);
   const [addTimeMode, setAddTimeMode] = useState(false);
-  const { currentIndex } = useBeverageStore();
+
+  const ampmOptions = [
+    { label: "오전", value: "AM" },
+    { label: "오후", value: "PM" },
+  ];
+  const hourOptions = Array.from({ length: 12 }, (_, i) => ({
+    label: String(i + 1),
+    value: String(i + 1),
+  }));
+  const minuteOptions = Array.from({ length: 60 }, (_, i) => ({
+    label: i.toString().padStart(2, "0"),
+    value: String(i),
+  }));
+
+  // 현재 시간 계산
+  const now = new Date();
+  const nowHour24 = now.getHours();
+  const nowMinute = now.getMinutes();
+  const initialAmpm = nowHour24 < 12 ? "AM" : "PM";
+  const initialHour = (nowHour24 % 12 || 12).toString();
+  const initialMinute = nowMinute.toString().padStart(2, "0");
+
+  const [ampm, setAmpm] = useState(initialAmpm);
+  const [hour, setHour] = useState(initialHour);
+  const [minute, setMinute] = useState(initialMinute);
 
   const setTimeMode = () => {
     // TODO: 음료량 기록 API 연동 시 삭제 + 연동하기
@@ -85,6 +108,40 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
             </TouchableOpacity>
             <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
           </View>
+
+          <View
+            style={{
+              flexDirection: "row",
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
+            <WheelPicker
+              height={172}
+              width={80}
+              items={ampmOptions}
+              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+              initialSelectedIndex={ampm === "AM" ? 0 : 1}
+              onChange={({ item }) => setAmpm(item.value)}
+            />
+            <WheelPicker
+              height={172}
+              width={80}
+              items={hourOptions}
+              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+              initialSelectedIndex={Number(hour) - 1}
+              onChange={({ item }) => setHour(item.value)}
+            />
+            <WheelPicker
+              height={172}
+              width={80}
+              items={minuteOptions}
+              selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+              initialSelectedIndex={Number(minute)}
+              onChange={({ item }) => setMinute(item.value)}
+            />
+          </View>
+
           <CustomButton title={"완료"} textStyle={{ fontWeight: "bold" }} onPress={addTime} />
         </View>
       )}

--- a/app/record-history/components/AddPastRecord.tsx
+++ b/app/record-history/components/AddPastRecord.tsx
@@ -11,6 +11,7 @@ import { TouchableOpacity, View } from "react-native";
 import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
 import RecordTimePickerSection from "@/components/CustomBottomSheet/RecordTimePickerSection";
 import addPastRecordStyles from "@/app/record-history/components/AddPastRecord.styles";
+import { verticalScale } from "@/libs/utils/scaling";
 
 interface addNewRecordProps {
   isOpen: boolean;
@@ -68,7 +69,11 @@ const AddNewRecord: React.FC<addNewRecordProps> = ({ isOpen, onClose }) => {
         <View style={addNewRecordStyles.bottomSheetContainer}>
           <View style={addPastRecordStyles.timeModeHeader}>
             <TouchableOpacity onPress={goBack}>
-              <MaterialIcons name={"arrow-back"} size={16} color={Colors.neutral_400} />
+              <MaterialIcons
+                name={"arrow-back"}
+                size={verticalScale(24)}
+                color={Colors.neutral_400}
+              />
             </TouchableOpacity>
             <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
           </View>

--- a/app/record-history/components/AmountStep.tsx
+++ b/app/record-history/components/AmountStep.tsx
@@ -1,0 +1,45 @@
+import { commonStyles } from "@/components/common.styles";
+import RecordAmountSection from "@/components/CustomBottomSheet/RecordAmountSection";
+import CustomButton from "@/components/CustomButton/CustomButton";
+import { CustomTab, TabType } from "@/components/CustomTab";
+import React from "react";
+import { View } from "react-native";
+import addPastRecordStyles from "./AddPastRecord.styles";
+
+interface AmountStepProps {
+  currentTab: TabType;
+  onSelectTab: (tab: TabType) => void;
+  currentVal: number;
+  setCurrentVal: (value: number) => void;
+  onNext: () => void;
+}
+
+const AmountStep: React.FC<AmountStepProps> = ({
+  currentTab,
+  onSelectTab,
+  currentVal,
+  setCurrentVal,
+  onNext,
+}) => {
+  return (
+    <View style={addPastRecordStyles.bottomSheetContainer}>
+      <View style={commonStyles.flexRow}>
+        <CustomTab
+          selectedTab={currentTab}
+          onSelectTab={onSelectTab}
+          visibleTabs={["물", "커피", "녹차"]}
+        />
+      </View>
+
+      <RecordAmountSection currentVal={currentVal} setCurrentVal={setCurrentVal} />
+
+      <CustomButton
+        title={"시간 추가"}
+        textStyle={{ fontWeight: "bold" }}
+        onPress={onNext}
+      />
+    </View>
+  );
+};
+
+export default AmountStep;

--- a/app/record-history/components/TimeStep.tsx
+++ b/app/record-history/components/TimeStep.tsx
@@ -1,0 +1,48 @@
+import RecordTimePickerSection from "@/components/CustomBottomSheet/RecordTimePickerSection";
+import CustomButton from "@/components/CustomButton/CustomButton";
+import { BN1 } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import { verticalScale } from "@/libs/utils/scaling";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import React from "react";
+import { TouchableOpacity, View } from "react-native";
+import addPastRecordStyles from "./AddPastRecord.styles";
+
+interface TimeStepProps {
+  selectedDate: Date;
+  setSelectedDate: (date: Date) => void;
+  onBack: () => void;
+  onSubmit: () => void;
+}
+
+const TimeStep: React.FC<TimeStepProps> = ({
+  selectedDate,
+  setSelectedDate,
+  onBack,
+  onSubmit,
+}) => {
+  return (
+    <View style={addPastRecordStyles.bottomSheetContainer}>
+      <View style={addPastRecordStyles.timeModeHeader}>
+        <TouchableOpacity onPress={onBack}>
+          <MaterialIcons
+            name={"arrow-back"}
+            size={verticalScale(24)}
+            color={Colors.neutral_400}
+          />
+        </TouchableOpacity>
+        <BN1 style={{ fontWeight: "bold" }}>시간 선택</BN1>
+      </View>
+
+      <RecordTimePickerSection value={selectedDate} onChange={setSelectedDate} />
+
+      <CustomButton
+        title={"완료"}
+        textStyle={{ fontWeight: "bold" }}
+        onPress={onSubmit}
+      />
+    </View>
+  );
+};
+
+export default TimeStep;

--- a/app/record-history/constants/drinkMapping.ts
+++ b/app/record-history/constants/drinkMapping.ts
@@ -1,0 +1,35 @@
+import { TabType } from "@/components/CustomTab";
+
+// 탭에 따른 drinkId 매핑
+export const drinkIdMap: Record<string, number> = {
+  All: 0,
+  Water: 1,
+  Coffee: 2,
+  GreenTea: 3,
+  Cola: 4,
+};
+
+// 한글 탭을 영어 키로 매핑
+export const tabToKeyMap = (tab: string): string => {
+  switch (tab) {
+    case "전체":
+      return "All";
+    case "물":
+      return "Water";
+    case "커피":
+      return "Coffee";
+    case "녹차":
+      return "GreenTea";
+    case "콜라":
+      return "Cola";
+    default:
+      return "Water";
+  }
+};
+
+// drinkId 가져오기 헬퍼 함수
+export const getDrinkId = (tab: TabType): number => {
+  return drinkIdMap[tabToKeyMap(tab)];
+};
+
+export default drinkIdMap;

--- a/app/record-history/hooks/useAddPastRecord.ts
+++ b/app/record-history/hooks/useAddPastRecord.ts
@@ -1,0 +1,97 @@
+import { TabType } from "@/components/CustomTab";
+import { useFormData } from "./useFormData";
+import { useStepManager } from "./useStepManager";
+import { useSubmitHandler } from "./useSubmitHandler";
+
+export interface UseAddPastRecordReturn {
+  // Form state
+  currentTab: TabType;
+  setCurrentTab: (tab: TabType) => void;
+  addTimeMode: boolean;
+
+  // Form values
+  currentVal: number;
+  selectedDate: Date;
+  setCurrentVal: (value: number) => void;
+  setSelectedDate: (date: Date) => void;
+
+  // Form methods
+  handleSubmit: (onSubmit: (data: any) => void) => (e?: React.BaseSyntheticEvent) => Promise<void>;
+  onSubmit: (data: any) => void;
+  reset: () => void;
+
+  // Actions
+  setTimeMode: () => void;
+  goBack: () => void;
+  handleClose: (onClose: () => void) => void;
+}
+
+export const useAddPastRecord = (): UseAddPastRecordReturn => {
+  const {
+    handleSubmit,
+    reset: resetForm,
+    currentVal,
+    selectedDate,
+    setCurrentVal,
+    setSelectedDate,
+    updateDrinkId,
+  } = useFormData();
+
+  const { currentTab, setCurrentTab, addTimeMode, goToTimeStep, goBackToAmountStep, resetSteps } =
+    useStepManager();
+
+  const { onSubmit: submitData } = useSubmitHandler();
+
+  const setTimeMode = () => {
+    const drinkId = goToTimeStep();
+    updateDrinkId(drinkId);
+  };
+
+  const onSubmit = (data: any) => {
+    submitData(data);
+    // 폼 초기화 및 스텝 리셋
+    resetForm();
+    resetSteps();
+  };
+
+  const goBack = () => {
+    goBackToAmountStep();
+  };
+
+  const handleClose = (onClose: () => void) => {
+    // 폼 초기화 및 모달 닫기
+    resetForm();
+    resetSteps();
+    onClose();
+  };
+
+  const reset = () => {
+    resetForm();
+    resetSteps();
+  };
+
+  return {
+    // Form state
+    currentTab,
+    setCurrentTab,
+    addTimeMode,
+
+    // Form values
+    currentVal,
+    selectedDate,
+    setCurrentVal,
+    setSelectedDate,
+
+    // Form methods
+    handleSubmit,
+    onSubmit,
+    reset,
+
+    // Actions
+    setTimeMode,
+    goBack,
+    handleClose,
+  };
+};
+
+export default useAddPastRecord;

--- a/app/record-history/hooks/useFormData.ts
+++ b/app/record-history/hooks/useFormData.ts
@@ -1,0 +1,45 @@
+import { useForm } from "react-hook-form";
+import { getDrinkId } from "../constants/drinkMapping";
+
+interface FormData {
+  drinkId: number;
+  amount: number;
+  drinkAt: string;
+}
+
+export const useFormData = () => {
+  const { handleSubmit, setValue, watch, reset } = useForm<FormData>({
+    defaultValues: {
+      drinkId: getDrinkId("물"),
+      amount: 500,
+      drinkAt: new Date().toISOString(),
+    },
+  });
+
+  const currentVal = watch("amount");
+  const selectedDate = new Date(watch("drinkAt"));
+
+  const setCurrentVal = (value: number) => {
+    setValue("amount", value);
+  };
+
+  const setSelectedDate = (date: Date) => {
+    setValue("drinkAt", date.toISOString());
+  };
+
+  const updateDrinkId = (drinkId: number) => {
+    setValue("drinkId", drinkId);
+  };
+
+  return {
+    handleSubmit,
+    reset,
+    currentVal,
+    selectedDate,
+    setCurrentVal,
+    setSelectedDate,
+    updateDrinkId,
+  };
+};
+
+export default useFormData;

--- a/app/record-history/hooks/useStepManager.ts
+++ b/app/record-history/hooks/useStepManager.ts
@@ -1,0 +1,33 @@
+import { TabType } from "@/components/CustomTab";
+import { useState } from "react";
+import { getDrinkId } from "../constants/drinkMapping";
+
+export const useStepManager = () => {
+  const [currentTab, setCurrentTab] = useState<TabType>("물");
+  const [addTimeMode, setAddTimeMode] = useState(false);
+
+  const goToTimeStep = () => {
+    setAddTimeMode(true);
+    return getDrinkId(currentTab);
+  };
+
+  const goBackToAmountStep = () => {
+    setAddTimeMode(false);
+  };
+
+  const resetSteps = () => {
+    setCurrentTab("물");
+    setAddTimeMode(false);
+  };
+
+  return {
+    currentTab,
+    setCurrentTab,
+    addTimeMode,
+    goToTimeStep,
+    goBackToAmountStep,
+    resetSteps,
+  };
+};
+
+export default useStepManager;

--- a/app/record-history/hooks/useSubmitHandler.ts
+++ b/app/record-history/hooks/useSubmitHandler.ts
@@ -1,0 +1,27 @@
+interface FormData {
+  drinkId: number;
+  amount: number;
+  drinkAt: string;
+}
+
+export const useSubmitHandler = () => {
+  const onSubmit = (data: FormData) => {
+    // 최종 데이터 구성
+    const submitData = {
+      drinkId: data.drinkId,
+      amount: data.amount,
+      drinkAt: data.drinkAt,
+    };
+
+    console.log("Submit Data:", submitData);
+    // TODO: API 연동 시 여기에 API 호출 로직 추가
+
+    return submitData;
+  };
+
+  return {
+    onSubmit,
+  };
+};
+
+export default useSubmitHandler;

--- a/app/record-history/index.styles.ts
+++ b/app/record-history/index.styles.ts
@@ -1,0 +1,5 @@
+import { StyleSheet } from "react-native";
+
+export const recordHistoryStyles = StyleSheet.create({});
+
+export default recordHistoryStyles;

--- a/app/record-history/index.tsx
+++ b/app/record-history/index.tsx
@@ -1,11 +1,17 @@
 import React from "react";
-import { Text, View } from "react-native";
+import { commonStyles } from "@/components/common.styles";
+import { ThemedView } from "@/components/ThemedView";
+import CustomButton from "@/components/CustomButton/CustomButton";
 
 const RecordHistory = () => {
   return (
-    <View>
-      <Text>RecordHistory</Text>
-    </View>
+    <ThemedView style={commonStyles.pageContainer}>
+      <CustomButton
+        title={"지난 기록 추가"}
+        variant={"secondary"}
+        textStyle={{ fontWeight: "bold" }}
+      />
+    </ThemedView>
   );
 };
 

--- a/app/record-history/index.tsx
+++ b/app/record-history/index.tsx
@@ -1,16 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 import { commonStyles } from "@/components/common.styles";
 import { ThemedView } from "@/components/ThemedView";
 import CustomButton from "@/components/CustomButton/CustomButton";
+import AddPastRecord from "@/app/record-history/components/AddPastRecord";
 
 const RecordHistory = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
     <ThemedView style={commonStyles.pageContainer}>
       <CustomButton
         title={"지난 기록 추가"}
         variant={"secondary"}
         textStyle={{ fontWeight: "bold" }}
+        onPress={() => setIsModalOpen(true)}
       />
+      <AddPastRecord isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
     </ThemedView>
   );
 };

--- a/app/record-history/index.tsx
+++ b/app/record-history/index.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Text, View } from "react-native";
+
+const RecordHistory = () => {
+  return (
+    <View>
+      <Text>RecordHistory</Text>
+    </View>
+  );
+};
+
+export default RecordHistory;

--- a/components/CommonHeader/CommonHeader.styles.ts
+++ b/components/CommonHeader/CommonHeader.styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from "react-native";
+import { verticalScale } from "@/libs/utils/scaling";
+
+export const commonHeaderStyles = StyleSheet.create({
+  commonHeaderContainer: {
+    height: verticalScale(56),
+    justifyContent: "center",
+  },
+});

--- a/components/CommonHeader/CommonHeader.styles.ts
+++ b/components/CommonHeader/CommonHeader.styles.ts
@@ -1,13 +1,15 @@
 import { StyleSheet } from "react-native";
-import { paddingScale, verticalScale } from "@/libs/utils/scaling";
+import { horizontalScale, paddingScale, verticalScale } from "@/libs/utils/scaling";
 
 export const commonHeaderStyles = StyleSheet.create({
   emptyHeader: {
     height: verticalScale(56),
   },
   commonHeaderContainer: {
+    flexDirection: "row",
     height: verticalScale(56),
-    justifyContent: "center",
+    gap: horizontalScale(16),
+    alignItems: "center",
     ...paddingScale(16),
   },
 });

--- a/components/CommonHeader/CommonHeader.styles.ts
+++ b/components/CommonHeader/CommonHeader.styles.ts
@@ -1,9 +1,13 @@
 import { StyleSheet } from "react-native";
-import { verticalScale } from "@/libs/utils/scaling";
+import { paddingScale, verticalScale } from "@/libs/utils/scaling";
 
 export const commonHeaderStyles = StyleSheet.create({
+  emptyHeader: {
+    height: verticalScale(56),
+  },
   commonHeaderContainer: {
     height: verticalScale(56),
     justifyContent: "center",
+    ...paddingScale(16),
   },
 });

--- a/components/CommonHeader/CommonHeader.tsx
+++ b/components/CommonHeader/CommonHeader.tsx
@@ -1,0 +1,32 @@
+import React, { ComponentProps } from "react";
+import { TouchableOpacity, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { MaterialIcons } from "@expo/vector-icons";
+import { Colors } from "@/constants/Colors";
+import { commonHeaderStyles } from "@/components/CommonHeader/CommonHeader.styles";
+import { useRouter } from "expo-router";
+
+interface CommonHeaderProps {
+  iconName?: ComponentProps<typeof MaterialIcons>["name"];
+  onPressIcon?: () => void;
+}
+
+const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon }) => {
+  const router = useRouter();
+
+  const goBack = () => {
+    router.back();
+  };
+
+  return (
+    <SafeAreaView>
+      <View style={commonHeaderStyles.commonHeaderContainer}>
+        <TouchableOpacity onPress={onPressIcon ?? goBack}>
+          <MaterialIcons name={iconName ?? "arrow-back"} size={24} color={Colors.neutral_400} />
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default CommonHeader;

--- a/components/CommonHeader/CommonHeader.tsx
+++ b/components/CommonHeader/CommonHeader.tsx
@@ -9,9 +9,10 @@ import { useRouter } from "expo-router";
 interface CommonHeaderProps {
   iconName?: ComponentProps<typeof MaterialIcons>["name"];
   onPressIcon?: () => void;
+  isEmpty?: boolean;
 }
 
-const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon }) => {
+const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon, isEmpty = false }) => {
   const router = useRouter();
 
   const goBack = () => {
@@ -19,12 +20,16 @@ const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon }) =>
   };
 
   return (
-    <SafeAreaView>
-      <View style={commonHeaderStyles.commonHeaderContainer}>
-        <TouchableOpacity onPress={onPressIcon ?? goBack}>
-          <MaterialIcons name={iconName ?? "arrow-back"} size={24} color={Colors.neutral_400} />
-        </TouchableOpacity>
-      </View>
+    <SafeAreaView style={{ backgroundColor: "white" }}>
+      {isEmpty ? (
+        <View style={commonHeaderStyles.emptyHeader} />
+      ) : (
+        <View style={commonHeaderStyles.commonHeaderContainer}>
+          <TouchableOpacity onPress={onPressIcon ?? goBack}>
+            <MaterialIcons name={iconName ?? "arrow-back"} size={24} color={Colors.neutral_400} />
+          </TouchableOpacity>
+        </View>
+      )}
     </SafeAreaView>
   );
 };

--- a/components/CommonHeader/CommonHeader.tsx
+++ b/components/CommonHeader/CommonHeader.tsx
@@ -5,14 +5,23 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { Colors } from "@/constants/Colors";
 import { commonHeaderStyles } from "@/components/CommonHeader/CommonHeader.styles";
 import { useRouter } from "expo-router";
+import { BN1 } from "@/components/ThemedText";
 
 interface CommonHeaderProps {
   iconName?: ComponentProps<typeof MaterialIcons>["name"];
   onPressIcon?: () => void;
   isEmpty?: boolean;
+  title?: string;
+  hasIcon?: boolean;
 }
 
-const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon, isEmpty = false }) => {
+const CommonHeader: React.FC<CommonHeaderProps> = ({
+  iconName,
+  onPressIcon,
+  isEmpty = false,
+  title,
+  hasIcon = true,
+}) => {
   const router = useRouter();
 
   const goBack = () => {
@@ -25,9 +34,16 @@ const CommonHeader: React.FC<CommonHeaderProps> = ({ iconName, onPressIcon, isEm
         <View style={commonHeaderStyles.emptyHeader} />
       ) : (
         <View style={commonHeaderStyles.commonHeaderContainer}>
-          <TouchableOpacity onPress={onPressIcon ?? goBack}>
-            <MaterialIcons name={iconName ?? "arrow-back"} size={24} color={Colors.neutral_400} />
-          </TouchableOpacity>
+          {hasIcon && (
+            <TouchableOpacity onPress={onPressIcon ?? goBack}>
+              <MaterialIcons name={iconName ?? "arrow-back"} size={24} color={Colors.neutral_400} />
+            </TouchableOpacity>
+          )}
+          {title && (
+            <BN1 lightColor={Colors.neutral_800} style={{ fontWeight: "bold" }}>
+              {title}
+            </BN1>
+          )}
         </View>
       )}
     </SafeAreaView>

--- a/components/CustomBottomSheet/RecordAmountSection.styles.ts
+++ b/components/CustomBottomSheet/RecordAmountSection.styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from "react-native";
+import { commonStyles } from "@/components/common.styles";
+import { horizontalScale } from "@/libs/utils/scaling";
+
+export const recordAmountSectionStyles = StyleSheet.create({
+  header: {
+    ...commonStyles.flexRow,
+    justifyContent: "space-between",
+  },
+  inputMeasurement: {
+    ...commonStyles.flexRow,
+    gap: horizontalScale(12),
+    alignItems: "center",
+  },
+});

--- a/components/CustomBottomSheet/RecordAmountSection.tsx
+++ b/components/CustomBottomSheet/RecordAmountSection.tsx
@@ -1,0 +1,49 @@
+// components/RecordAmountSection.tsx
+import React, { Fragment } from "react";
+import { View } from "react-native";
+import { BN1, LN1 } from "@/components/ThemedText";
+import CustomSlider from "@/components/CustomSlider/CustomSlider";
+import { Colors } from "@/constants/Colors";
+import { recordAmountSectionStyles } from "@/components/CustomBottomSheet/RecordAmountSection.styles";
+
+interface RecordAmountSectionProps {
+  currentVal: number;
+  setCurrentVal: (val: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+const RecordAmountSection: React.FC<RecordAmountSectionProps> = ({
+  currentVal,
+  setCurrentVal,
+  min = 0,
+  max = 1000,
+  step = 50,
+}) => (
+  <Fragment>
+    <View style={recordAmountSectionStyles.header}>
+      <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
+        마신 양을 얼마나 추가할까요?
+      </BN1>
+
+      <View style={recordAmountSectionStyles.inputMeasurement}>
+        <BN1 lightColor={Colors.neutral_700} style={{ fontWeight: "bold" }}>
+          {currentVal}
+        </BN1>
+        <LN1 lightColor={Colors.neutral_400}>ml</LN1>
+      </View>
+    </View>
+
+    <CustomSlider
+      sliderVal={currentVal}
+      onValueChange={(val) => setCurrentVal(val[0])}
+      step={step}
+      animationType={"spring"}
+      maximumValue={max}
+      minimumValue={min}
+    />
+  </Fragment>
+);
+
+export default RecordAmountSection;

--- a/components/CustomBottomSheet/RecordAmountSection.tsx
+++ b/components/CustomBottomSheet/RecordAmountSection.tsx
@@ -17,7 +17,7 @@ interface RecordAmountSectionProps {
 const RecordAmountSection: React.FC<RecordAmountSectionProps> = ({
   currentVal,
   setCurrentVal,
-  min = 0,
+  min = 50,
   max = 1000,
   step = 50,
 }) => (

--- a/components/CustomBottomSheet/RecordTimePickerSection.styles.ts
+++ b/components/CustomBottomSheet/RecordTimePickerSection.styles.ts
@@ -1,10 +1,25 @@
 import { StyleSheet } from "react-native";
 import { commonStyles } from "@/components/common.styles";
+import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
+import { Colors } from "@/constants/Colors";
 
 export const recordTimePickerSectionStyles = StyleSheet.create({
   timePickerWrapper: {
     ...commonStyles.flexRow,
     justifyContent: "center",
     alignItems: "center",
+  },
+  wheelPickerSelectedItem: {
+    borderColor: Colors.neutral_200,
+    borderWidth: horizontalScale(1),
+  },
+  timeDot: {
+    height: verticalScale(35),
+    borderColor: Colors.neutral_200,
+    borderTopWidth: horizontalScale(1),
+    borderBottomWidth: horizontalScale(1),
+    flexDirection: "column",
+    verticalAlign: "middle",
+    fontWeight: "bold",
   },
 });

--- a/components/CustomBottomSheet/RecordTimePickerSection.styles.ts
+++ b/components/CustomBottomSheet/RecordTimePickerSection.styles.ts
@@ -1,0 +1,10 @@
+import { StyleSheet } from "react-native";
+import { commonStyles } from "@/components/common.styles";
+
+export const recordTimePickerSectionStyles = StyleSheet.create({
+  timePickerWrapper: {
+    ...commonStyles.flexRow,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});

--- a/components/CustomBottomSheet/RecordTimePickerSection.tsx
+++ b/components/CustomBottomSheet/RecordTimePickerSection.tsx
@@ -1,10 +1,10 @@
-import { Colors } from "@/constants/Colors";
 import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
 import React, { useEffect, useState } from "react";
 import { View } from "react-native";
 import WheelPicker from "react-native-wheel-picker-expo";
 import { combinePickerToDate, splitDateToPicker } from "@/hooks/useDateTimeTransform";
 import { recordTimePickerSectionStyles } from "@/components/CustomBottomSheet/RecordTimePickerSection.styles";
+import { HL1 } from "@/components/ThemedText";
 
 interface RecordTimePickerSectionProps {
   value: Date;
@@ -20,7 +20,7 @@ const RecordTimePickerSection: React.FC<RecordTimePickerSectionProps> = ({ value
     label: String(i + 1),
     value: String(i + 1),
   }));
-  const minuteOptions = Array.from({ length: 60 }, (_, i) => ({
+  const minuteOptions = Array.from({ length: 65 }, (_, i) => ({
     label: i.toString().padStart(2, "0"),
     value: String(i),
   }));
@@ -46,25 +46,29 @@ const RecordTimePickerSection: React.FC<RecordTimePickerSectionProps> = ({ value
     <View style={recordTimePickerSectionStyles.timePickerWrapper}>
       <WheelPicker
         height={verticalScale(172)}
-        width={horizontalScale(75)}
+        width={horizontalScale(65)}
         items={ampmOptions}
-        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        selectedStyle={recordTimePickerSectionStyles.wheelPickerSelectedItem}
         initialSelectedIndex={ampm === "AM" ? 0 : 1}
         onChange={({ item }) => setAmpm(item.value)}
       />
+
       <WheelPicker
         height={verticalScale(172)}
-        width={horizontalScale(75)}
+        width={horizontalScale(65)}
         items={hourOptions}
-        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        selectedStyle={recordTimePickerSectionStyles.wheelPickerSelectedItem}
         initialSelectedIndex={Number(hour) - 1}
         onChange={({ item }) => setHour(item.value)}
       />
+
+      <HL1 style={recordTimePickerSectionStyles.timeDot}>:</HL1>
+
       <WheelPicker
         height={verticalScale(172)}
-        width={horizontalScale(75)}
+        width={horizontalScale(65)}
         items={minuteOptions}
-        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        selectedStyle={recordTimePickerSectionStyles.wheelPickerSelectedItem}
         initialSelectedIndex={Number(minute)}
         onChange={({ item }) => setMinute(item.value)}
       />

--- a/components/CustomBottomSheet/RecordTimePickerSection.tsx
+++ b/components/CustomBottomSheet/RecordTimePickerSection.tsx
@@ -1,0 +1,75 @@
+import { Colors } from "@/constants/Colors";
+import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
+import React, { useEffect, useState } from "react";
+import { View } from "react-native";
+import WheelPicker from "react-native-wheel-picker-expo";
+import { combinePickerToDate, splitDateToPicker } from "@/hooks/useDateTimeTransform";
+import { recordTimePickerSectionStyles } from "@/components/CustomBottomSheet/RecordTimePickerSection.styles";
+
+interface RecordTimePickerSectionProps {
+  value: Date;
+  onChange: (date: Date) => void;
+}
+
+const RecordTimePickerSection: React.FC<RecordTimePickerSectionProps> = ({ value, onChange }) => {
+  const ampmOptions = [
+    { label: "오전", value: "AM" },
+    { label: "오후", value: "PM" },
+  ];
+  const hourOptions = Array.from({ length: 12 }, (_, i) => ({
+    label: String(i + 1),
+    value: String(i + 1),
+  }));
+  const minuteOptions = Array.from({ length: 60 }, (_, i) => ({
+    label: i.toString().padStart(2, "0"),
+    value: String(i),
+  }));
+
+  // value prop이 바뀔 때마다 picker state를 동기화
+  const { ampm: initialAmpm, hour: initialHour, minute: initialMinute } = splitDateToPicker(value);
+  const [ampm, setAmpm] = useState(initialAmpm);
+  const [hour, setHour] = useState(initialHour);
+  const [minute, setMinute] = useState(initialMinute);
+
+  useEffect(() => {
+    setAmpm(initialAmpm);
+    setHour(initialHour);
+    setMinute(initialMinute);
+  }, [value]);
+
+  useEffect(() => {
+    const newDate = combinePickerToDate(value, ampm, hour, minute);
+    onChange(newDate);
+  }, [ampm, hour, minute]);
+
+  return (
+    <View style={recordTimePickerSectionStyles.timePickerWrapper}>
+      <WheelPicker
+        height={verticalScale(172)}
+        width={horizontalScale(75)}
+        items={ampmOptions}
+        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        initialSelectedIndex={ampm === "AM" ? 0 : 1}
+        onChange={({ item }) => setAmpm(item.value)}
+      />
+      <WheelPicker
+        height={verticalScale(172)}
+        width={horizontalScale(75)}
+        items={hourOptions}
+        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        initialSelectedIndex={Number(hour) - 1}
+        onChange={({ item }) => setHour(item.value)}
+      />
+      <WheelPicker
+        height={verticalScale(172)}
+        width={horizontalScale(75)}
+        items={minuteOptions}
+        selectedStyle={{ borderColor: Colors.neutral_200, borderWidth: 1 }}
+        initialSelectedIndex={Number(minute)}
+        onChange={({ item }) => setMinute(item.value)}
+      />
+    </View>
+  );
+};
+
+export default RecordTimePickerSection;

--- a/components/CustomInput/CustomInput.hooks.ts
+++ b/components/CustomInput/CustomInput.hooks.ts
@@ -1,0 +1,43 @@
+import { Control, FieldPath, FieldValues, useController } from "react-hook-form";
+
+/**
+ * react-hook-form과 통합된 CustomInput 훅
+ * 
+ * @param name - 폼 필드명
+ * @param control - react-hook-form의 control 객체
+ * @param rules - 유효성 검사 규칙
+ * @param defaultValue - 기본값
+ * @returns 폼 컨트롤에 필요한 props들
+ */
+export function useCustomInput<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({
+  name,
+  control,
+  rules,
+  defaultValue,
+}: {
+  name: TName;
+  control: Control<TFieldValues>;
+  rules?: any;
+  defaultValue?: any;
+}) {
+  const {
+    field: { onChange, onBlur, value },
+    fieldState: { error },
+  } = useController({
+    name,
+    control,
+    rules,
+    defaultValue,
+  });
+
+  return {
+    value: value || "",
+    onChangeText: onChange,
+    onBlur,
+    isError: !!error,
+    errorText: error?.message,
+  };
+}

--- a/components/CustomInput/CustomInput.styles.ts
+++ b/components/CustomInput/CustomInput.styles.ts
@@ -6,17 +6,15 @@ export const customInputStyles = StyleSheet.create({
   container: {
     marginBottom: verticalScale(4),
   },
-  
   label: {
+    fontWeight: "bold",
     marginBottom: verticalScale(8),
   },
-  
   inputWrapper: {
     flexDirection: "row",
     alignItems: "center",
     position: "relative",
   },
-  
   input: {
     flex: 1,
     height: verticalScale(48),
@@ -35,6 +33,10 @@ export const customInputStyles = StyleSheet.create({
     backgroundColor: Colors.danger_100 + "10", // 10% opacity
   },
   
+  inputFocused: {
+    borderColor: Colors.primary_500,
+    borderWidth: 2,
+  },
   // Icon containers
   leftIconContainer: {
     position: "absolute",
@@ -43,7 +45,6 @@ export const customInputStyles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
-  
   rightIconContainer: {
     position: "absolute",
     right: horizontalScale(12),
@@ -51,15 +52,12 @@ export const customInputStyles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
-  
   inputWithLeftIcon: {
     paddingLeft: horizontalScale(44),
   },
-  
   inputWithRightIcon: {
     paddingRight: horizontalScale(44),
   },
-  
   errorText: {
     marginTop: verticalScale(4),
   },

--- a/components/CustomInput/CustomInput.styles.ts
+++ b/components/CustomInput/CustomInput.styles.ts
@@ -1,0 +1,66 @@
+import { Colors } from "@/constants/Colors";
+import { horizontalScale, paddingScale, verticalScale } from "@/libs/utils/scaling";
+import { StyleSheet } from "react-native";
+
+export const customInputStyles = StyleSheet.create({
+  container: {
+    marginBottom: verticalScale(4),
+  },
+  
+  label: {
+    marginBottom: verticalScale(8),
+  },
+  
+  inputWrapper: {
+    flexDirection: "row",
+    alignItems: "center",
+    position: "relative",
+  },
+  
+  input: {
+    flex: 1,
+    height: verticalScale(48),
+    ...paddingScale(12, 16),
+    fontSize: 16,
+    lineHeight: 24,
+    letterSpacing: 0.0912,
+    borderRadius: verticalScale(12),
+    borderWidth: 1,
+    borderColor: Colors.neutral_200,
+    backgroundColor: Colors.neutral_000,
+  },
+  
+  inputError: {
+    borderColor: Colors.danger_200,
+    backgroundColor: Colors.danger_100 + "10", // 10% opacity
+  },
+  
+  // Icon containers
+  leftIconContainer: {
+    position: "absolute",
+    left: horizontalScale(12),
+    zIndex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  
+  rightIconContainer: {
+    position: "absolute",
+    right: horizontalScale(12),
+    zIndex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  
+  inputWithLeftIcon: {
+    paddingLeft: horizontalScale(44),
+  },
+  
+  inputWithRightIcon: {
+    paddingRight: horizontalScale(44),
+  },
+  
+  errorText: {
+    marginTop: verticalScale(4),
+  },
+});

--- a/components/CustomInput/CustomInput.styles.ts
+++ b/components/CustomInput/CustomInput.styles.ts
@@ -1,6 +1,7 @@
 import { Colors } from "@/constants/Colors";
 import { horizontalScale, paddingScale, verticalScale } from "@/libs/utils/scaling";
 import { StyleSheet } from "react-native";
+import { presetStyles } from "@/components/styles/TextPresets";
 
 export const customInputStyles = StyleSheet.create({
   container: {
@@ -9,7 +10,10 @@ export const customInputStyles = StyleSheet.create({
   label: {
     fontWeight: "bold",
     marginBottom: verticalScale(8),
+    marginLeft: horizontalScale(8),
   },
+
+  // input
   inputWrapper: {
     flexDirection: "row",
     alignItems: "center",
@@ -17,26 +21,22 @@ export const customInputStyles = StyleSheet.create({
   },
   input: {
     flex: 1,
-    height: verticalScale(48),
-    ...paddingScale(12, 16),
-    fontSize: 16,
-    lineHeight: 24,
-    letterSpacing: 0.0912,
-    borderRadius: verticalScale(12),
+    ...paddingScale(16),
+    ...presetStyles.BN2,
     borderWidth: 1,
+    borderRadius: verticalScale(12),
     borderColor: Colors.neutral_200,
     backgroundColor: Colors.neutral_000,
   },
-  
   inputError: {
     borderColor: Colors.danger_200,
-    backgroundColor: Colors.danger_100 + "10", // 10% opacity
+    backgroundColor: Colors.danger_100 + "10",
   },
-  
   inputFocused: {
     borderColor: Colors.primary_500,
-    borderWidth: 2,
+    borderWidth: 1,
   },
+
   // Icon containers
   leftIconContainer: {
     position: "absolute",
@@ -58,7 +58,14 @@ export const customInputStyles = StyleSheet.create({
   inputWithRightIcon: {
     paddingRight: horizontalScale(44),
   },
+
+  // Text
   errorText: {
-    marginTop: verticalScale(4),
+    marginTop: verticalScale(8),
+    marginLeft: horizontalScale(8),
+  },
+  detailText: {
+    marginTop: verticalScale(8),
+    marginLeft: horizontalScale(8),
   },
 });

--- a/components/CustomInput/CustomInput.tsx
+++ b/components/CustomInput/CustomInput.tsx
@@ -1,0 +1,78 @@
+import { customInputStyles } from "@/components/CustomInput/CustomInput.styles";
+import { L2, LN1 } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import React from "react";
+import { TextInput, TextInputProps, View } from "react-native";
+
+export interface CustomInputProps extends TextInputProps {
+  label?: string;
+  errorText?: string;
+  isError?: boolean;
+  rightIcon?: React.ReactNode;
+  leftIcon?: React.ReactNode;
+}
+
+/**
+ * CustomInput
+ *
+ * 프로젝트의 디자인 시스템에 맞는 커스텀 Input 컴포넌트입니다.
+ * - Label, ErrorText를 포함한 완전한 폼 필드 컴포넌트
+ * - react-hook-form과의 통합을 고려한 설계
+ * - 다양한 variant와 상태를 지원
+ *
+ * @component
+ * @param {string} [label] - Input 위에 표시될 라벨
+ * @param {string} [errorText] - 에러 상태일 때 표시될 메시지
+ * @param {boolean} [isError=false] - 에러 상태 여부
+ * @param {React.ReactNode} [rightIcon] - 오른쪽에 표시할 아이콘
+ * @param {React.ReactNode} [leftIcon] - 왼쪽에 표시할 아이콘
+ * @param {TextInputProps} [...props] - 추가 TextInput 속성
+ * @returns {JSX.Element}
+ */
+const CustomInput: React.FC<CustomInputProps> = ({
+  label,
+  errorText,
+  isError = false,
+  rightIcon,
+  leftIcon,
+  style,
+  editable = true,
+  ...props
+}) => {
+  return (
+    <View style={customInputStyles.container}>
+      {label && (
+        <LN1 style={customInputStyles.label} lightColor={Colors.neutral_700}>
+          {label}
+        </LN1>
+      )}
+
+      <View style={customInputStyles.inputWrapper}>
+        {leftIcon && <View style={customInputStyles.leftIconContainer}>{leftIcon}</View>}
+
+        <TextInput
+          style={[
+            customInputStyles.input,
+            isError ? customInputStyles.inputError : null,
+            leftIcon ? customInputStyles.inputWithLeftIcon : null,
+            rightIcon ? customInputStyles.inputWithRightIcon : null,
+            style,
+          ]}
+          editable={editable}
+          placeholderTextColor={Colors.neutral_400}
+          {...props}
+        />
+
+        {rightIcon && <View style={customInputStyles.rightIconContainer}>{rightIcon}</View>}
+      </View>
+
+      {errorText && isError && (
+        <L2 style={customInputStyles.errorText} lightColor={Colors.danger_200}>
+          {errorText}
+        </L2>
+      )}
+    </View>
+  );
+};
+
+export default CustomInput;

--- a/components/CustomInput/CustomInput.tsx
+++ b/components/CustomInput/CustomInput.tsx
@@ -7,6 +7,7 @@ import { TextInput, TextInputProps, View } from "react-native";
 export interface CustomInputProps extends TextInputProps {
   label?: string;
   errorText?: string;
+  detailText?: string;
   errorCondition?: (value: string) => boolean;
   rightIcon?: React.ReactNode;
   leftIcon?: React.ReactNode;
@@ -23,6 +24,7 @@ export interface CustomInputProps extends TextInputProps {
  * @component
  * @param {string} [label] - Input 위에 표시될 라벨
  * @param {string} [errorText] - 에러 상태일 때 표시될 메시지
+ * @param {string} [detailText] - 추가적인 정보를 표시하는 메시지
  * @param {(value: string) => boolean} [errorCondition] - 에러 조건을 확인하는 함수 (true면 에러)
  * @param {React.ReactNode} [rightIcon] - 오른쪽에 표시할 아이콘
  * @param {React.ReactNode} [leftIcon] - 왼쪽에 표시할 아이콘
@@ -32,6 +34,7 @@ export interface CustomInputProps extends TextInputProps {
 const CustomInput: React.FC<CustomInputProps> = ({
   label,
   errorText,
+  detailText,
   errorCondition,
   rightIcon,
   leftIcon,
@@ -94,6 +97,12 @@ const CustomInput: React.FC<CustomInputProps> = ({
       {errorText && isError && (
         <L2 style={customInputStyles.errorText} lightColor={Colors.danger_200}>
           {errorText}
+        </L2>
+      )}
+
+      {detailText && !isError && (
+        <L2 style={customInputStyles.detailText} lightColor={Colors.neutral_500}>
+          {detailText}
         </L2>
       )}
     </View>

--- a/components/CustomInput/CustomInput.types.ts
+++ b/components/CustomInput/CustomInput.types.ts
@@ -1,0 +1,15 @@
+import { TextInputProps } from "react-native";
+
+export interface CustomInputProps extends TextInputProps {
+  label?: string;
+  errorText?: string;
+  isError?: boolean;
+  rightIcon?: React.ReactNode;
+  leftIcon?: React.ReactNode;
+}
+
+export interface UseCustomInputProps {
+  name: string;
+  rules?: any;
+  defaultValue?: any;
+}

--- a/components/CustomInput/CustomInput.types.ts
+++ b/components/CustomInput/CustomInput.types.ts
@@ -3,7 +3,7 @@ import { TextInputProps } from "react-native";
 export interface CustomInputProps extends TextInputProps {
   label?: string;
   errorText?: string;
-  isError?: boolean;
+  errorCondition?: (value: string) => boolean;
   rightIcon?: React.ReactNode;
   leftIcon?: React.ReactNode;
 }

--- a/components/CustomInput/index.ts
+++ b/components/CustomInput/index.ts
@@ -1,0 +1,4 @@
+export { default as CustomInput } from "./CustomInput";
+export { useCustomInput } from "./CustomInput.hooks";
+export type { CustomInputProps, UseCustomInputProps } from "./CustomInput.types";
+

--- a/components/CustomSlider/CustomSlider.tsx
+++ b/components/CustomSlider/CustomSlider.tsx
@@ -27,7 +27,7 @@ interface CustomSliderProps extends Partial<SliderProps> {
 const CustomSlider: React.FC<CustomSliderProps> = ({
   sliderVal,
   onValueChange,
-  trackMarks = [0, 1000],
+  trackMarks = [50, 1000],
   ...props
 }) => {
   const renderTrackMark = (index: number) => <TrackMark value={trackMarks[index]} />;

--- a/components/CustomSlider/TrackMark.tsx
+++ b/components/CustomSlider/TrackMark.tsx
@@ -3,13 +3,14 @@ import { ThemedView } from "@/components/ThemedView";
 import { Colors } from "@/constants/Colors";
 import React from "react";
 import { StyleSheet } from "react-native";
-import { verticalScale } from "@/libs/utils/scaling";
+import { horizontalScale, verticalScale } from "@/libs/utils/scaling";
 
 export const trackMarkStyles = StyleSheet.create({
   StyledThemedView: {
     backgroundColor: "transparent",
     height: verticalScale(80),
     justifyContent: "flex-end",
+    marginLeft: horizontalScale(10),
   },
 });
 

--- a/components/TodayGoalMoisture/TodayGoal.tsx
+++ b/components/TodayGoalMoisture/TodayGoal.tsx
@@ -1,14 +1,17 @@
 import React from "react";
-import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { TouchableOpacity, View } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import { MaterialIcons, MaterialCommunityIcons } from "@expo/vector-icons";
+import { MaterialCommunityIcons, MaterialIcons } from "@expo/vector-icons";
 import styles from "./TodayGoal.styles";
 
 import { Colors } from "@/constants/Colors";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
+import { useRouter } from "expo-router";
 
 export default function TodayGoalCard() {
+  const router = useRouter();
+
   return (
     <LinearGradient
       colors={["#FFFFFFFF", "#CDD1D57A"]}
@@ -23,7 +26,9 @@ export default function TodayGoalCard() {
             <ThemedText style={styles.goalText}>오늘의 목표 수분</ThemedText>
             <TouchableOpacity style={styles.settingButton}>
               <View style={styles.settingContent}>
-                <ThemedText style={styles.settingText}>개인설정</ThemedText>
+                <ThemedText style={styles.settingText} onPress={() => router.push("/(settings)")}>
+                  개인설정
+                </ThemedText>
                 <MaterialIcons
                   name="keyboard-arrow-right"
                   size={16}

--- a/components/TodayGoalMoisture/TodayGoal.tsx
+++ b/components/TodayGoalMoisture/TodayGoal.tsx
@@ -24,11 +24,12 @@ export default function TodayGoalCard() {
           {/* Top Row: 텍스트 + 버튼 */}
           <View style={styles.topRow}>
             <ThemedText style={styles.goalText}>오늘의 목표 수분</ThemedText>
-            <TouchableOpacity style={styles.settingButton}>
+            <TouchableOpacity
+              style={styles.settingButton}
+              onPress={() => router.push("/(settings)")}
+            >
               <View style={styles.settingContent}>
-                <ThemedText style={styles.settingText} onPress={() => router.push("/(settings)")}>
-                  개인설정
-                </ThemedText>
+                <ThemedText style={styles.settingText}>개인설정</ThemedText>
                 <MaterialIcons
                   name="keyboard-arrow-right"
                   size={16}

--- a/components/common.styles.ts
+++ b/components/common.styles.ts
@@ -5,6 +5,7 @@ import { StyleSheet } from "react-native";
 export const commonStyles = StyleSheet.create({
   pageContainer: {
     // main 페이지 기준 패딩 적용
+    flex: 1,
     ...paddingScale(8, 16),
   },
   transparentView: {

--- a/hooks/useDateTimeTransform.ts
+++ b/hooks/useDateTimeTransform.ts
@@ -1,0 +1,20 @@
+export function splitDateToPicker(date: Date) {
+  const hour24 = date.getHours();
+  const ampm = hour24 < 12 ? "AM" : "PM";
+  const hour12 = hour24 % 12 || 12;
+  const minute = date.getMinutes();
+  return {
+    ampm,
+    hour: hour12.toString(),
+    minute: minute.toString().padStart(2, "0"),
+  };
+}
+
+export function combinePickerToDate(base: Date, ampm: string, hour: string, minute: string) {
+  let hour24 = Number(hour) % 12;
+  if (ampm === "PM") hour24 += 12;
+  if (ampm === "AM" && hour24 === 12) hour24 = 0;
+  const newDate = new Date(base);
+  newDate.setHours(hour24, Number(minute), 0, 0);
+  return newDate;
+}


### PR DESCRIPTION
<img width="530" height="1114" alt="image" src="https://github.com/user-attachments/assets/f8796608-dd7a-4bb7-bbdd-d6d659f79fca" />


## ✅ Done
- 개인 설정 페이지 기본 뼈대 구성

## 📝 Note
- 현재 로그인 정보 클릭 시 상세 페이지 이동 외에는 모든 부분 별도 구현이 필요합니다. (토글 버튼은 작동 됩니다 🙂)
- 직접 설정 시 표시되는 모달창도 구현이 필요합니다.